### PR TITLE
Improve function signature for entity updates.

### DIFF
--- a/pkg/db/generic/generic.go
+++ b/pkg/db/generic/generic.go
@@ -13,8 +13,6 @@ const entityAlreadyModifiedErrorMessage = "the entity was changed from another, 
 type (
 	// Entity is an interface that allows metal entities to be created and stored
 	// into the database with the generic creation and update functions.
-	//
-	// see https://go.googlesource.com/proposal/+/HEAD/design/43651-type-parameters.md#pointer-method-example for possible solution to prevent slices of pointers.
 	Entity interface {
 		// GetID returns the entity's id
 		GetID() string
@@ -23,6 +21,8 @@ type (
 		// GetChanged returns the entity's changed time
 		GetChanged() time.Time
 		// SetChanged sets the entity's changed time
+		// TODO: it would be great if SetChanged would be private such that the caller cannot tamper with the modification timestamps
+		//       probably this also applies to SetCreated and SetID
 		SetChanged(changed time.Time)
 		// GetCreated sets the entity's creation time
 		GetCreated() time.Time
@@ -34,7 +34,7 @@ type (
 
 	Storage[E Entity] interface {
 		Create(ctx context.Context, e E) (E, error)
-		Update(ctx context.Context, new, old E) error
+		Update(ctx context.Context, e E) error
 		Upsert(ctx context.Context, e E) error
 		Delete(ctx context.Context, e E) error
 		Get(ctx context.Context, id string) (E, error)

--- a/pkg/db/generic/migrations/08_childprefixlength.go
+++ b/pkg/db/generic/migrations/08_childprefixlength.go
@@ -69,7 +69,7 @@ func init() {
 					new.DefaultChildPrefixLength = defaultChildPrefixLength
 				}
 
-				err = ds.Network().Update(ctx, &new, old)
+				err = ds.Network().Update(ctx, &new)
 				if err != nil {
 					return err
 				}

--- a/pkg/db/generic/rethinkdb_test.go
+++ b/pkg/db/generic/rethinkdb_test.go
@@ -39,9 +39,8 @@ func TestGenericCRUD(t *testing.T) {
 	require.Equal(t, "1.2.3.4", created.IPAddress)
 	require.NotNil(t, created.Created)
 
-	newIP := *created
-	newIP.Description = "Modified IP"
-	err = ds.IP().Update(ctx, &newIP, created)
+	created.Description = "Modified IP"
+	err = ds.IP().Update(ctx, created)
 	require.NoError(t, err)
 
 	updated, err := ds.IP().Get(ctx, "1.2.3.4")

--- a/pkg/repository/filesystemlayout.go
+++ b/pkg/repository/filesystemlayout.go
@@ -101,9 +101,11 @@ func (r *filesystemLayoutRepository) Update(ctx context.Context, rq *Validated[*
 		return nil, errorutil.Convert(err)
 	}
 
+	newFsl.SetChanged(old.Changed)
+
 	// FIXME implement update logic
 
-	err = r.r.ds.FilesystemLayout().Update(ctx, newFsl, old)
+	err = r.r.ds.FilesystemLayout().Update(ctx, newFsl)
 	if err != nil {
 		return nil, errorutil.Convert(err)
 	}

--- a/pkg/repository/image.go
+++ b/pkg/repository/image.go
@@ -160,7 +160,7 @@ func (r *imageRepository) Update(ctx context.Context, rq *Validated[*adminv2.Ima
 		new.URL = image.Url
 	}
 
-	err = r.r.ds.Image().Update(ctx, &new, old)
+	err = r.r.ds.Image().Update(ctx, &new)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/ip.go
+++ b/pkg/repository/ip.go
@@ -268,7 +268,7 @@ func (r *ipRepository) Update(ctx context.Context, req *Validated[*apiv2.IPServi
 		new.Tags = tags
 	}
 
-	err = r.r.ds.IP().Update(ctx, &new, old)
+	err = r.r.ds.IP().Update(ctx, &new)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/partition.go
+++ b/pkg/repository/partition.go
@@ -162,7 +162,9 @@ func (p *partitionRepository) Update(ctx context.Context, req *Validated[*adminv
 		return nil, errorutil.Convert(err)
 	}
 
-	err = p.r.ds.Partition().Update(ctx, new, old)
+	new.SetChanged(old.Changed)
+
+	err = p.r.ds.Partition().Update(ctx, new)
 	if err != nil {
 		return nil, errorutil.Convert(err)
 	}


### PR DESCRIPTION
## Description

This improves the update function such that callers do not have to `new := *old`  anymore, which already lead to ugly bugs in the past when developers just did `new := old`.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
