### PR TITLE
Allow only prefixes on boundaries, prevent overlaps on update and fix update

### DIFF
--- a/pkg/db/metal/network.go
+++ b/pkg/db/metal/network.go
@@ -212,11 +212,6 @@ func (p *Prefix) String() string {
 	return p.IP + "/" + p.Length
 }
 
-// equals returns true when prefixes have the same cidr.
-func (p *Prefix) equals(other *Prefix) bool {
-	return p.String() == other.String()
-}
-
 func (p Prefixes) String() []string {
 	result := []string{}
 	for _, element := range p {
@@ -295,7 +290,7 @@ func NewPrefixesFromCIDRs(cidrs []string) (Prefixes, error) {
 func NewPrefixFromCIDR(cidr string) (*Prefix, *netip.Prefix, error) {
 	prefix, err := netip.ParsePrefix(cidr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("given cidr %q is not a valid ip with mask: %w", cidr, err)
+		return nil, nil, err
 	}
 	ip := prefix.Addr().String()
 	length := strconv.Itoa(prefix.Bits())
@@ -306,10 +301,12 @@ func NewPrefixFromCIDR(cidr string) (*Prefix, *netip.Prefix, error) {
 }
 
 // SubtractPrefixes returns the prefixes of the network minus the prefixes passed in the arguments
-func (n *Network) SubtractPrefixes(prefixes ...Prefix) []Prefix {
-	return slices.DeleteFunc(n.Prefixes, func(a Prefix) bool {
-		return slices.ContainsFunc(prefixes, func(b Prefix) bool {
-			return a.equals(&b)
+func (p Prefixes) SubtractPrefixes(target ...Prefix) []Prefix {
+	var copy Prefixes
+	copy = append(copy, p...)
+	return slices.DeleteFunc(copy, func(a Prefix) bool {
+		return slices.ContainsFunc(target, func(b Prefix) bool {
+			return a.String() == b.String()
 		})
 	})
 }

--- a/pkg/db/metal/network_test.go
+++ b/pkg/db/metal/network_test.go
@@ -178,9 +178,7 @@ func TestNetwork_SubtractPrefixes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := &metal.Network{Prefixes: tt.existing}
-
-			if diff := cmp.Diff(tt.want, metal.Prefixes(n.SubtractPrefixes(tt.subtract...))); diff != "" {
+			if diff := cmp.Diff(tt.want, metal.Prefixes(tt.existing.SubtractPrefixes(tt.subtract...))); diff != "" {
 				t.Errorf("diff = %s", diff)
 			}
 		})

--- a/pkg/repository/network-validation.go
+++ b/pkg/repository/network-validation.go
@@ -645,7 +645,7 @@ func (*networkRepository) validatePrefixesOnBoundaries(prefixes []string) error 
 			return err
 		}
 		if parsed.Masked().String() != pfx {
-			errs = append(errs, fmt.Errorf("malformed prefix %q given, please specify it as %q", pfx, parsed.Masked().String()))
+			errs = append(errs, fmt.Errorf("expecting canonical form of prefix %q, please specify it as %q", pfx, parsed.Masked().String()))
 		}
 	}
 

--- a/pkg/repository/network-validation.go
+++ b/pkg/repository/network-validation.go
@@ -501,7 +501,12 @@ func (r *networkRepository) ValidateUpdate(ctx context.Context, req *adminv2.Net
 		destPrefixAfs       metal.AddressFamilies
 	)
 
-	prefixesToBeRemoved, prefixesToBeAdded, err = r.calculatePrefixDifferences(ctx, old, req.Prefixes)
+	prefixesToBeRemoved, prefixesToBeAdded, err = r.calculatePrefixDifferences(old, req.Prefixes)
+	if err != nil {
+		return nil, errorutil.Convert(err)
+	}
+
+	err = r.arePrefixesEmpty(ctx, prefixesToBeRemoved)
 	if err != nil {
 		return nil, errorutil.Convert(err)
 	}

--- a/pkg/repository/network-validation.go
+++ b/pkg/repository/network-validation.go
@@ -491,6 +491,10 @@ func (r *networkRepository) ValidateUpdate(ctx context.Context, req *adminv2.Net
 		return nil, errorutil.InvalidArgument("cannot change prefixes in child networks")
 	}
 
+	if len(req.Prefixes) == 0 && !metal.IsChildNetwork(old.NetworkType) {
+		return nil, errorutil.InvalidArgument("removing all prefixes is not supported")
+	}
+
 	if err := r.validatePrefixesOnBoundaries(req.Prefixes); err != nil {
 		return nil, errorutil.NewInvalidArgument(err)
 	}
@@ -569,7 +573,7 @@ func (r *networkRepository) arePrefixesEmpty(ctx context.Context, prefixes metal
 			return errorutil.Convert(err)
 		}
 		if len(ips) > 0 {
-			return errorutil.InvalidArgument("there are still %d ips present in prefix: %s", len(ips), prefixToCheck)
+			return errorutil.InvalidArgument("there are still %d ips present in prefix: %s", len(ips), prefixToCheck.String())
 		}
 	}
 	return nil

--- a/pkg/repository/network-validation_test.go
+++ b/pkg/repository/network-validation_test.go
@@ -133,13 +133,13 @@ func Test_networkRepository_validatePrefixesOnBoundaries(t *testing.T) {
 		{
 			name:     "one incorrect ipv4",
 			prefixes: []string{"10.0.0.0/8", "192.168.1.0/24", "10.105.0.0/14"},
-			wantErr:  errors.New(`malformed prefix "10.105.0.0/14" given, please specify it as "10.104.0.0/14"`),
+			wantErr:  errors.New(`expecting canonical form of prefix "10.105.0.0/14", please specify it as "10.104.0.0/14"`),
 		},
 		{
 			name:     "two incorrect ipv4",
 			prefixes: []string{"20.105.0.0/14", "10.0.0.0/8", "192.168.1.0/24", "10.105.0.0/14"},
-			wantErr: errors.New(`malformed prefix "20.105.0.0/14" given, please specify it as "20.104.0.0/14"
-malformed prefix "10.105.0.0/14" given, please specify it as "10.104.0.0/14"`),
+			wantErr: errors.New(`expecting canonical form of prefix "20.105.0.0/14", please specify it as "20.104.0.0/14"
+expecting canonical form of prefix "10.105.0.0/14", please specify it as "10.104.0.0/14"`),
 		},
 		{
 			name:     "correct ipv6",
@@ -148,7 +148,7 @@ malformed prefix "10.105.0.0/14" given, please specify it as "10.104.0.0/14"`),
 		{
 			name:     "one incorrect ipv6",
 			prefixes: []string{"2001:abcd:1::/96", "2001:abcd:1:1::/48"},
-			wantErr:  errors.New(`malformed prefix "2001:abcd:1:1::/48" given, please specify it as "2001:abcd:1::/48"`),
+			wantErr:  errors.New(`expecting canonical form of prefix "2001:abcd:1:1::/48", please specify it as "2001:abcd:1::/48"`),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/repository/network.go
+++ b/pkg/repository/network.go
@@ -325,10 +325,21 @@ func (r *networkRepository) Update(ctx context.Context, rq *Validated[*adminv2.N
 		prefixesToBeAdded   metal.Prefixes
 	)
 
-	prefixesToBeRemoved, prefixesToBeAdded, err = r.calculatePrefixDifferences(ctx, old, &newNetwork, req.Prefixes)
+	// Ensure child networks can be updated without loosing the prefixes.
+	if metal.IsChildNetwork(old.NetworkType) {
+		req.Prefixes = old.Prefixes.String()
+	}
+
+	prefixesToBeRemoved, prefixesToBeAdded, err = r.calculatePrefixDifferences(ctx, old, req.Prefixes)
 	if err != nil {
 		return nil, errorutil.Convert(err)
 	}
+
+	pfxs, err := metal.NewPrefixesFromCIDRs(req.Prefixes)
+	if err != nil {
+		return nil, errorutil.Convert(err)
+	}
+	newNetwork.Prefixes = pfxs
 
 	if req.DestinationPrefixes != nil {
 		destPrefixes, err := metal.NewPrefixesFromCIDRs(req.DestinationPrefixes)
@@ -540,7 +551,7 @@ func (r *networkRepository) scopedNetworkFilters(filter generic.EntityQuery) []g
 	return qs
 }
 
-func (r *networkRepository) calculatePrefixDifferences(ctx context.Context, existingNetwork, newNetwork *metal.Network, prefixes []string) (toRemoved, toAdded metal.Prefixes, err error) {
+func (r *networkRepository) calculatePrefixDifferences(ctx context.Context, existingNetwork *metal.Network, prefixes []string) (toRemoved, toAdded metal.Prefixes, err error) {
 	if len(prefixes) == 0 {
 		return
 	}
@@ -549,14 +560,14 @@ func (r *networkRepository) calculatePrefixDifferences(ctx context.Context, exis
 		return nil, nil, err
 	}
 
-	toRemoved = existingNetwork.SubtractPrefixes(pfxs...)
+	toRemoved = existingNetwork.Prefixes.SubtractPrefixes(pfxs...)
 
 	err = r.arePrefixesEmpty(ctx, toRemoved)
 	if err != nil {
 		return nil, nil, err
 	}
-	toAdded = newNetwork.SubtractPrefixes(existingNetwork.Prefixes...)
-	newNetwork.Prefixes = pfxs
+
+	toAdded = pfxs.SubtractPrefixes(existingNetwork.Prefixes...)
 	return toRemoved, toAdded, nil
 }
 

--- a/pkg/repository/network_test.go
+++ b/pkg/repository/network_test.go
@@ -1,0 +1,61 @@
+package repository
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/metal-stack/metal-apiserver/pkg/db/metal"
+)
+
+func Test_networkRepository_calculatePrefixDifferences(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingNetwork *metal.Network
+		prefixes        []string
+		wantToRemoved   metal.Prefixes
+		wantToAdded     metal.Prefixes
+		wantErr         bool
+	}{
+		{
+			name:            "nothing to add or remove",
+			existingNetwork: &metal.Network{Prefixes: metal.Prefixes{{IP: "10.0.0.0", Length: "8"}}},
+			prefixes:        []string{"10.0.0.0/8"},
+			wantToRemoved:   metal.Prefixes{},
+			wantToAdded:     metal.Prefixes{},
+			wantErr:         false,
+		},
+		{
+			name:            "one to add none to remove",
+			existingNetwork: &metal.Network{Prefixes: metal.Prefixes{{IP: "10.0.0.0", Length: "8"}}},
+			prefixes:        []string{"10.0.0.0/8", "11.0.0.0/8"},
+			wantToRemoved:   metal.Prefixes{},
+			wantToAdded:     metal.Prefixes{{IP: "11.0.0.0", Length: "8"}},
+			wantErr:         false,
+		},
+		{
+			name:            "one to add one to remove",
+			existingNetwork: &metal.Network{Prefixes: metal.Prefixes{{IP: "9.0.0.0", Length: "8"}, {IP: "10.0.0.0", Length: "8"}}},
+			prefixes:        []string{"10.0.0.0/8", "11.0.0.0/8"},
+			wantToRemoved:   metal.Prefixes{{IP: "9.0.0.0", Length: "8"}},
+			wantToAdded:     metal.Prefixes{{IP: "11.0.0.0", Length: "8"}},
+			wantErr:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &networkRepository{}
+
+			gotToRemoved, gotToAdded, err := r.calculatePrefixDifferences(tt.existingNetwork, tt.prefixes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("networkRepository.calculatePrefixDifferences() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotToRemoved, tt.wantToRemoved) {
+				t.Errorf("networkRepository.calculatePrefixDifferences() gotToRemoved = %v, want %v", gotToRemoved, tt.wantToRemoved)
+			}
+			if !reflect.DeepEqual(gotToAdded, tt.wantToAdded) {
+				t.Errorf("networkRepository.calculatePrefixDifferences() gotToAdded = %v, want %v", gotToAdded, tt.wantToAdded)
+			}
+		})
+	}
+}

--- a/pkg/service/network/admin/network-service_test.go
+++ b/pkg/service/network/admin/network-service_test.go
@@ -1304,7 +1304,7 @@ func Test_networkServiceServer_CreateExternal(t *testing.T) {
 				Vrf:      pointer.Pointer(uint32(94)),
 			},
 			want:    nil,
-			wantErr: errorutil.InvalidArgument(`malformed prefix "1.2.3.0/22" given, please specify it as "1.2.0.0/22"`),
+			wantErr: errorutil.InvalidArgument(`expecting canonical form of prefix "1.2.3.0/22", please specify it as "1.2.0.0/22"`),
 		},
 		{
 			name: "internet",
@@ -2065,7 +2065,7 @@ func Test_networkServiceServer_Update(t *testing.T) {
 				Prefixes: []string{"10.100.0.0/14", "10.105.0.0/14"},
 			},
 			want:    nil,
-			wantErr: errorutil.InvalidArgument(`malformed prefix "10.105.0.0/14" given, please specify it as "10.104.0.0/14"`),
+			wantErr: errorutil.InvalidArgument(`expecting canonical form of prefix "10.105.0.0/14", please specify it as "10.104.0.0/14"`),
 		},
 		{
 			name: "remove all prefixes",


### PR DESCRIPTION
## Description

Fixes the following:

- prefix difference calculation on update was not working
- prefix overlap checks on update where missing
- prefixes must be specified on bitmask boundary now to be aligned with the prefix stored in ipam
- prevent removing all prefixes on update

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
