### PR TITLE
Use synctest to leverage fake time during tests

### DIFF
--- a/pkg/auth/opaauther-integration_test.go
+++ b/pkg/auth/opaauther-integration_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
@@ -19,6 +19,18 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
+
+func TestTime(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now() // always midnight UTC 2000-01-01
+		go func() {
+			time.Sleep(1 * time.Second)
+			t.Log(time.Since(start)) // always logs "1s"
+		}()
+		time.Sleep(2 * time.Second) // the goroutine above will run before this Sleep returns
+		t.Log(time.Since(start))    // always logs "2s"
+	})
+}
 
 func Test_opa_cert_rotation(t *testing.T) {
 	oldMaxExpiration := token.MaxExpiration
@@ -34,58 +46,59 @@ func Test_opa_cert_rotation(t *testing.T) {
 
 	t.Logf("token lifetime: %s, certificate lifetime: %s, issue new signing certificate after: %s", token.DefaultExpiration, 2*token.MaxExpiration, 2*token.MaxExpiration-renewCertBeforeExpiration)
 
-	var (
-		s   = miniredis.RunT(t)
-		c   = redis.NewClient(&redis.Options{Addr: s.Addr()})
-		log = slog.Default()
+	s := miniredis.RunT(t)
+	c := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	log := slog.Default()
 
-		certStore = certs.NewRedisStore(&certs.Config{
-			RedisClient:               c,
-			RenewCertBeforeExpiration: &renewCertBeforeExpiration,
+	certStore := certs.NewRedisStore(&certs.Config{
+		RedisClient:               c,
+		RenewCertBeforeExpiration: &renewCertBeforeExpiration,
+	})
+	tokenStore := token.NewRedisStore(c)
+
+	opa := func() *opa {
+		o, err := New(Config{
+			Log:            log,
+			CertStore:      certStore,
+			CertCacheTime:  pointer.Pointer(0 * time.Second),
+			TokenStore:     tokenStore,
+			AllowedIssuers: []string{"integration"},
 		})
-		tokenStore = token.NewRedisStore(c)
+		require.NoError(t, err)
 
-		opa = func() *opa {
-			o, err := New(Config{
-				Log:            log,
-				CertStore:      certStore,
-				CertCacheTime:  pointer.Pointer(0 * time.Second),
-				TokenStore:     tokenStore,
-				AllowedIssuers: []string{"integration"},
-			})
-			require.NoError(t, err)
+		o.projectsAndTenantsGetter = func(ctx context.Context, userId string) (*repository.ProjectsAndTenants, error) {
+			return &repository.ProjectsAndTenants{
+				ProjectRoles: map[string]v1.ProjectRole{
+					"test-project": v1.ProjectRole_PROJECT_ROLE_VIEWER,
+				},
+			}, nil
+		}
 
-			o.projectsAndTenantsGetter = func(ctx context.Context, userId string) (*repository.ProjectsAndTenants, error) {
-				return &repository.ProjectsAndTenants{
-					ProjectRoles: map[string]v1.ProjectRole{
-						"test-project": v1.ProjectRole_PROJECT_ROLE_VIEWER,
-					},
-				}, nil
-			}
+		return o
+	}()
+	service := func() tokenservice.TokenService {
+		s := tokenservice.New(tokenservice.Config{
+			Log:           log,
+			CertStore:     certStore,
+			TokenStore:    tokenStore,
+			AdminSubjects: []string{},
+			Issuer:        "integration",
+		})
 
-			return o
-		}()
+		return s
+	}()
 
-		ctx     = t.Context()
-		service = func() tokenservice.TokenService {
-			s := tokenservice.New(tokenservice.Config{
-				Log:           log,
-				CertStore:     certStore,
-				TokenStore:    tokenStore,
-				AdminSubjects: []string{},
-				Issuer:        "integration",
-			})
+	synctest.Test(t, func(t *testing.T) {
 
-			return s
-		}()
+		ctx := t.Context()
 
-		token1 = ""
-		token2 = ""
-		token3 = ""
-
-		wg sync.WaitGroup
-
-		steps = []struct {
+		var (
+			token1     = ""
+			token2     = ""
+			token3     = ""
+			previousAt *time.Duration
+		)
+		steps := []struct {
 			name string
 			at   time.Duration
 			task func(t *testing.T)
@@ -162,34 +175,15 @@ func Test_opa_cert_rotation(t *testing.T) {
 				},
 			},
 		}
-	)
 
-	var (
-		start      = time.Now().Add(1 * time.Second)
-		previousAt *time.Duration
-		mtx        sync.Mutex
-	)
+		time.Sleep(1 * time.Second)
 
-	for _, step := range steps {
-		step := step
-
-		wg.Add(1)
-
-		go t.Run(step.name, func(t *testing.T) {
-			defer wg.Done()
-
-			childCtx, cancel := context.WithDeadline(ctx, start.Add(step.at))
-			defer cancel()
-
-			<-childCtx.Done()
-
-			mtx.Lock()
-			defer mtx.Unlock()
-
+		for _, step := range steps {
 			forwardText := ""
 			if previousAt != nil {
 				forward := step.at - *previousAt
-				forwardText = fmt.Sprintf(" (forwarding redis by %s)", forward)
+				forwardText = fmt.Sprintf(" (forwarding by %s)", forward)
+				time.Sleep(forward)
 				s.FastForward(forward)
 			}
 			previousAt = &step.at
@@ -197,10 +191,8 @@ func Test_opa_cert_rotation(t *testing.T) {
 			t.Logf("%s: running step at %q%s: %q", time.Now(), step.at, forwardText, step.name)
 
 			step.task(t)
-		})
-	}
-
-	wg.Wait()
+		}
+	})
 }
 
 func createNewConsoleToken(t *testing.T, ctx context.Context, service tokenservice.TokenService) string {


### PR DESCRIPTION
## Description

Since go-1.25 synctest allows to use time which operates on a fake time.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
