### PR TITLE
Do not link test dependencies into main binary

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Lint Go
         uses: golangci/golangci-lint-action@v8
+        
 
       - name: Build
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ run:
   concurrency: 4
   build-tags:
     - integration
+    - export
 
 linters:
   disable:

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ server:
 
 .PHONY: test
 test:
-	go test ./... -race -coverpkg=./... -coverprofile=coverage.out -covermode=atomic $(GO_TEST_ARGS) -timeout=300s && go tool cover -func=coverage.out
+	go test ./... -tags export -race -coverpkg=./... -coverprofile=coverage.out -covermode=atomic $(GO_TEST_ARGS) -timeout=300s && go tool cover -func=coverage.out
 
 .PHONY: bench
 bench:
-	CGO_ENABLED=1 go test -bench=. -run=^$$ ./... -benchmem -timeout 20m
+	CGO_ENABLED=1 go test -bench=. -run=^$$ ./... -tags export -benchmem -timeout 20m
 
 .PHONY: mocks
 mocks:

--- a/cmd/server/serve-cmd.go
+++ b/cmd/server/serve-cmd.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
-	"testing"
 
 	"connectrpc.com/connect"
 	"github.com/alicebob/miniredis/v2"
@@ -16,11 +15,11 @@ import (
 
 	ipamv1 "github.com/metal-stack/go-ipam/api/v1"
 	ipamv1connect "github.com/metal-stack/go-ipam/api/v1/apiv1connect"
+	ipamtest "github.com/metal-stack/go-ipam/pkg/test"
 	mdm "github.com/metal-stack/masterdata-api/pkg/client"
 	"github.com/metal-stack/metal-apiserver/pkg/db/generic"
 	"github.com/metal-stack/metal-apiserver/pkg/repository"
 	"github.com/metal-stack/metal-apiserver/pkg/service"
-	"github.com/metal-stack/metal-apiserver/pkg/test"
 
 	"github.com/metal-stack/metal-lib/auditing"
 	"github.com/metal-stack/v"
@@ -306,7 +305,8 @@ func createIpamClient(cli *cli.Context, log *slog.Logger) (ipamv1connect.IpamSer
 	log.Info("create ipam client", "stage", cli.String(stageFlag.Name))
 	if cli.String(stageFlag.Name) == stageDEV {
 		log.Warn("ipam grpc endpoint not configured, starting in memory ipam service")
-		ipam, _ := test.StartIpam(&testing.T{})
+		ipam, _ := ipamtest.NewTestServer(cli.Context, log)
+
 		return ipam, nil
 	}
 

--- a/pkg/test/asynq.go
+++ b/pkg/test/asynq.go
@@ -1,3 +1,6 @@
+//go:build export
+// +build export
+
 package test
 
 import (

--- a/pkg/test/ipam.go
+++ b/pkg/test/ipam.go
@@ -1,3 +1,6 @@
+//go:build export
+// +build export
+
 package test
 
 import (

--- a/pkg/test/masterdata.go
+++ b/pkg/test/masterdata.go
@@ -1,3 +1,6 @@
+//go:build export
+// +build export
+
 package test
 
 import (

--- a/pkg/test/repository.go
+++ b/pkg/test/repository.go
@@ -1,3 +1,6 @@
+//go:build export
+// +build export
+
 package test
 
 import (

--- a/pkg/test/rethinkdb.go
+++ b/pkg/test/rethinkdb.go
@@ -1,3 +1,6 @@
+//go:build export
+// +build export
+
 package test
 
 import (

--- a/pkg/test/validate.go
+++ b/pkg/test/validate.go
@@ -1,3 +1,6 @@
+//go:build export
+// +build export
+
 package test
 
 import (

--- a/pkg/test/valkey.go
+++ b/pkg/test/valkey.go
@@ -1,3 +1,6 @@
+//go:build export
+// +build export
+
 package test
 
 import (


### PR DESCRIPTION
## Description

Imports in go files which are not named according to the go test naming convention `_test.go` will be included in the main binary. OTOH exported funcs in `_test.go` files can not be imported in other packages.

To circumvent this a build flag is introduced, which separates test code from production code.

This saves ~1Mb from the resulting binary and the testcontainers dependency can no longer be found like so:

```
$ strings bin/server | grep testcontainers

dep     github.com/testcontainers/testcontainers-go     v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
dep     github.com/testcontainers/testcontainers-go/modules/postgres    v0.38.0 h1:KFdx9A0yF94K70T6ibSuvgkQQeX1xKlZVF3hEagXEtY=
dep     github.com/testcontainers/testcontainers-go/modules/valkey      v0.40.0 h1:V0zwJVnN8fOT++ySwo/P5cwd3pmXI7O4VdA7kQ+5OiM=
github.com/testcontainers/testcontainers-go/internal/config.init
github.com/testcontainers/testcontainers-go/internal/core.init
github.com/testcontainers/testcontainers-go/internal/core.init.0
github.com/testcontainers/testcontainers-go/internal/core.init.1
github.com/testcontainers/testcontainers-go/log.init.0
github.com/testcontainers/testcontainers-go/log.noopLogger.Printf
github.com/testcontainers/testcontainers-go/log.(*noopLogger).Printf
github.com/testcontainers/testcontainers-go/wait.init
github.com/testcontainers/testcontainers-go.init
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/internal/config/config.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/internal/core/docker_host.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/internal/core/docker_socket.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/internal/core/images.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/internal/core/bootstrap.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/log/logger.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/wait/walk.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/docker.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/docker_mounts.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/docker_auth.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/port_forwarding.go
/home/stefan/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.40.0/testing.go
dep     github.com/testcontainers/testcontainers-go     v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
dep     github.com/testcontainers/testcontainers-go/modules/postgres    v0.38.0 h1:KFdx9A0yF94K70T6ibSuvgkQQeX1xKlZVF3hEagXEtY=
dep     github.com/testcontainers/testcontainers-go/modules/valkey      v0.40.0 h1:V0zwJVnN8fOT++ySwo/P5cwd3pmXI7O4VdA7kQ+5OiM=
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
