### PR TITLE
Fix vpn-healthcheck nil pointer on startup

### DIFF
--- a/cmd/server/serve-cmd.go
+++ b/cmd/server/serve-cmd.go
@@ -15,6 +15,8 @@ import (
 	"github.com/valkey-io/valkey-go"
 	"gopkg.in/rethinkdb/rethinkdb-go.v6"
 
+	headscalev1 "github.com/juanfont/headscale/gen/go/headscale/v1"
+
 	ipamv1 "github.com/metal-stack/go-ipam/api/v1"
 	ipamv1connect "github.com/metal-stack/go-ipam/api/v1/apiv1connect"
 	mdm "github.com/metal-stack/masterdata-api/pkg/client"
@@ -115,7 +117,10 @@ func newServeCmd() *cli.Command {
 				return fmt.Errorf("unable to create masterdata.client: %w", err)
 			}
 
-			var hc *headscale.Client
+			var (
+				hc                 *headscale.Client
+				headscaleApiClient headscalev1.HeadscaleServiceClient
+			)
 
 			if ctx.Bool(headscaleEnabledFlag.Name) {
 				hc, err = headscale.NewClient(headscale.Config{
@@ -126,6 +131,7 @@ func newServeCmd() *cli.Command {
 				if err != nil {
 					return err
 				}
+				headscaleApiClient = hc.HeadscaleServiceClient
 
 				log.Info("headscale enabled")
 			} else {
@@ -196,7 +202,7 @@ func newServeCmd() *cli.Command {
 				IsStageDev:                          strings.EqualFold(stage, stageDEV),
 				BMCSuperuserPassword:                ctx.String(bmcSuperuserPasswordFlag.Name),
 				HeadscaleControlplaneAddress:        ctx.String(headscaleControlplaneAddressFlag.Name),
-				HeadscaleClient:                     hc,
+				HeadscaleClient:                     headscaleApiClient,
 				ComponentExpiration:                 ctx.Duration(componentExpirationFlag.Name),
 			}
 


### PR DESCRIPTION
## Description

This was a regression of #181 , fix it

```
metal-apiserver-57df6f9466-5r942 apiserver {"time":"2026-04-08T09:16:27.03135409Z","level":"INFO","msg":"headscale is not enabled, not configuring vpn services"}                                                                               
metal-apiserver-57df6f9466-5r942 apiserver {"time":"2026-04-08T09:16:27.031371615Z","level":"INFO","msg":"create rethinkdb client","datastore":{"datastore":{"addresses":["metal-db"],"dbname":"metalapi","user":"metal","password":"change-me"}
}}                                                                                                                                                                                                                                              
metal-apiserver-57df6f9466-5r942 apiserver {"time":"2026-04-08T09:16:27.04381506Z","level":"INFO","msg":"ensured provider tenant","id":"metal-stack"}                                                                                           
metal-apiserver-57df6f9466-5r942 apiserver {"time":"2026-04-08T09:16:27.043832323Z","level":"INFO","msg":"running api-server","version":"f782eed (f782eed7), remotes/pull/128/merge-0-gf782eed, 2026-04-08T08:16:22+00:00, go1.26.2","go-runtime
":"go1.26.2","http-endpoint":"0.0.0.0:8080"}                                                                                                                                                                                                    
metal-apiserver-57df6f9466-5r942 apiserver panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                              
metal-apiserver-57df6f9466-5r942 apiserver [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16aa23d]                                                                                                                              
metal-apiserver-57df6f9466-5r942 apiserver                                                                                                                                                                                                      
metal-apiserver-57df6f9466-5r942 apiserver goroutine 190 [running]:                                                                                                                                                                             
metal-apiserver-57df6f9466-5r942 apiserver github.com/metal-stack/metal-apiserver/pkg/headscale.(*Client).Health(0x0?, {0x27f8718?, 0x382b00090640?}, 0x382aff26dd60?, {0x0?, 0x382aff766080?, 0x35?})                                          
metal-apiserver-57df6f9466-5r942 apiserver      <autogenerated>:1 +0x1d                                                                                                                                                                         
metal-apiserver-57df6f9466-5r942 apiserver github.com/metal-stack/metal-apiserver/pkg/service/api/health.(*vpnHealthChecker).Health(0x382b00066b20, {0x27f8718, 0x382b00090640})                                                                
metal-apiserver-57df6f9466-5r942 apiserver      /home/runner/work/metal-apiserver/metal-apiserver/pkg/service/api/health/vpn-checker.go:15 +0x5a                                                                                                
metal-apiserver-57df6f9466-5r942 apiserver github.com/metal-stack/metal-apiserver/pkg/service/api/health.(*healthServiceServer).updateStatuses.func2()                                                                                          
metal-apiserver-57df6f9466-5r942 apiserver      /home/runner/work/metal-apiserver/metal-apiserver/pkg/service/api/health/health-service.go:150 +0x4c                                                                                            
metal-apiserver-57df6f9466-5r942 apiserver golang.org/x/sync/errgroup.(*Group).Go.func1()                                                                                                                                                       
metal-apiserver-57df6f9466-5r942 apiserver      /home/runner/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 +0x50                                                                                                                 
metal-apiserver-57df6f9466-5r942 apiserver created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 173                                                                                                                                   
metal-apiserver-57df6f9466-5r942 apiserver      /home/runner/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:78 +0x95
```

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
