### PR TITLE
Fix issues ai found

### DIFF
--- a/pkg/repository/machine.go
+++ b/pkg/repository/machine.go
@@ -376,7 +376,7 @@ func (r *machineRepository) convertToProto(ctx context.Context, m *metal.Machine
 
 	for _, gpu := range m.Hardware.MetalGPUs {
 		gpus = append(gpus, &apiv2.MetalGPU{
-			Vendor: gpu.Model,
+			Vendor: gpu.Vendor,
 			Model:  gpu.Model,
 		})
 	}
@@ -876,7 +876,7 @@ func (r *machineRepository) InstallationSucceeded(ctx context.Context, req *infr
 		return nil, fmt.Errorf("unknown allocation role:%q found", role)
 	}
 	if vrf == "" {
-		return nil, fmt.Errorf("the machine %q could not be put into the vrf because no vrf was found, error: %w", req.Uuid, err)
+		return nil, fmt.Errorf("the machine %q could not be put into the vrf because no vrf was found", req.Uuid)
 	}
 
 	// TODO convert to tasks


### PR DESCRIPTION
## Description

Regarding logout: this endpoint is not called from the `cli` on logout ?

### F-23 — GPU Vendor field set to Model value ✅

- **File:** `pkg/repository/machine.go:378-382`
- **Severity:** MEDIUM
- **Details:** `Vendor: gpu.Model` should be `Vendor: gpu.Vendor`. Both vendor and model are set to the same value (the GPU model), losing the actual vendor information.
- **Impact:** `Vendor` field always equals `Model`, making it impossible to distinguish NVIDIA from AMD GPUs in API responses.
- **Recommendation:** Change to `Vendor: gpu.Vendor`.

### F-24 — Nil error wrapped in fmt.Errorf ✅

- **File:** `pkg/repository/machine.go:879`
- **Severity:** MEDIUM
- **Details:** When `vrf` is empty (because no private network was found for a machine), the function returns `fmt.Errorf("... error: %w", err)` where `err` is nil. This is because `err` was never assigned in the `role` switch statement below.
- **Impact:** The error message contains "error: <nil>" which is confusing and indicates a bug.
- **Recommendation:** Initialize `err` before the switch or use a separate error creation.

### F-27 — GPU field double-mapping ✅

- **File:** `pkg/repository/machine.go:378-382`
- **Severity:** LOW
- **Details:** (See F-23 — tracked as separate finding for the `Model` field: `Model: gpu.Model` is correct, the bug is solely the `Vendor` line.)

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- dgx-spark with Qwen-3.6 used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
