### PR TITLE
Introduce secure-cookie flag

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -333,6 +333,12 @@ var (
 		Usage:   "duration after which inactive component entries are removed",
 		EnvVars: []string{"COMPONENT_EXPIRATION"},
 	}
+	secureCookieFlag = &cli.BoolFlag{
+		Name:    "secure-cookie",
+		Value:   true,
+		Usage:   "enable secure cookie transport, should be disabled in mini-lab or test and dev environments where authentication endpoint is not https terminated",
+		EnvVars: []string{"SECURE_COOKIE"},
+	}
 )
 
 func main() {

--- a/cmd/server/serve-cmd.go
+++ b/cmd/server/serve-cmd.go
@@ -83,6 +83,7 @@ func newServeCmd() *cli.Command {
 			headscaleApikeyFlag,
 			headscaleEnabledFlag,
 			componentExpirationFlag,
+			secureCookieFlag,
 		},
 		Action: func(ctx *cli.Context) error {
 			log, err := createLogger(ctx)
@@ -191,6 +192,7 @@ func newServeCmd() *cli.Command {
 				OIDCUniqueUserKey:                   ctx.String(oidcUniqueUserKeyFlag.Name),
 				OIDCTLSSkipVerify:                   ctx.Bool(oidcTLSSkipVerifyFlag.Name),
 				IsStageDev:                          strings.EqualFold(stage, stageDEV),
+				SecureCookie:                        ctx.Bool(secureCookieFlag.Name),
 				BMCSuperuserPassword:                ctx.String(bmcSuperuserPasswordFlag.Name),
 				HeadscaleControlplaneAddress:        ctx.String(headscaleControlplaneAddressFlag.Name),
 				HeadscaleClient:                     hc,

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -15,7 +15,7 @@ func Test_newServeCmd(t *testing.T) {
 	args := []string{"-h"}
 
 	cmd := newServeCmd()
-	require.Len(t, cmd.Flags, 47)
+	require.Len(t, cmd.Flags, 48)
 
 	app.Commands = []*cli.Command{cmd}
 	err := app.Run(args)

--- a/pkg/service/auth/auth-service.go
+++ b/pkg/service/auth/auth-service.go
@@ -40,6 +40,8 @@ type Config struct {
 	CallbackUrl   string // will replace `"{" + providerKey + ""}"` with the actual provider name
 	FrontEndUrl   *url.URL
 	CookieMaxAge  time.Duration
+	IsDevStage    bool
+	SecureCookie  bool
 }
 
 type providerUser struct {
@@ -64,6 +66,8 @@ type auth struct {
 	frontEndUrl      *url.URL
 	callbackUrl      string
 	repo             *repository.Store
+	isDevStage       bool
+	secureCookie     bool
 }
 
 type authOption func(*auth) error
@@ -81,12 +85,12 @@ func New(c Config, options ...authOption) (*auth, error) {
 	return a.With(options...)
 }
 
-func (a *auth) NewHandler(isDevStage bool) (string, http.Handler, error) {
-	a.log.Info("authhandler", "isDevStage", isDevStage)
+func (a *auth) NewHandler() (string, http.Handler, error) {
+	a.log.Info("authhandler", "isDevStage", a.isDevStage)
 	// FIXME: since go-1.22 and goth v1.81 can be replaced by
 	// r := http.NewServeMux()
 	r := mux.NewRouter()
-	if isDevStage {
+	if a.isDevStage {
 		_, err := a.With(FakeProvider())
 		if err != nil {
 			return "", nil, err
@@ -100,6 +104,7 @@ func (a *auth) NewHandler(isDevStage bool) (string, http.Handler, error) {
 			Path:     "/",
 			MaxAge:   86400 * 30,
 			SameSite: http.SameSiteLaxMode,
+			Secure:   a.secureCookie,
 		},
 	}
 

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -68,6 +68,7 @@ type Config struct {
 	MaxRequestsPerMinuteToken           int
 	MaxRequestsPerMinuteUnauthenticated int
 	IsStageDev                          bool
+	SecureCookie                        bool
 	BMCSuperuserPassword                string
 	HeadscaleControlplaneAddress        string
 	HeadscaleClient                     *headscale.Client
@@ -252,6 +253,8 @@ func oidcAuthHandler(log *slog.Logger, tokenService token.TokenService, c Config
 		AuditBackends: c.AuditBackends,
 		FrontEndUrl:   frontendURL,
 		CallbackUrl:   c.ServerHttpURL + "/auth/{provider}/callback",
+		IsDevStage:    c.IsStageDev,
+		SecureCookie:  c.SecureCookie,
 	})
 	if err != nil {
 		return "", nil, err
@@ -271,6 +274,6 @@ func oidcAuthHandler(log *slog.Logger, tokenService token.TokenService, c Config
 		return "", nil, err
 	}
 
-	return auth.NewHandler(c.IsStageDev)
+	return auth.NewHandler()
 
 }


### PR DESCRIPTION
## Description

Closes #212 

TODO:

- [ ] https://github.com/metal-stack/mini-lab/pull/304
- [ ] https://github.com/metal-stack/metal-roles/pull/620
- [ ] https://github.com/metal-stack/helm-charts/pull/162

### 9. Session Cookie Lacks `Secure` Flag ✅

**Files:** `pkg/service/auth/auth-service.go:99-103`

The gothic session cookie is configured with `Path: "/"`, `MaxAge: 86400 * 30`, and `SameSite: Lax`, but the `Secure` flag is not set. This means session cookies will be transmitted **over unencrypted HTTP connections**, exposing session identifiers to interception on network-level threats (e.g., man-in-the-middle, rogue Wi-Fi).

**Recommendation:** Set `Secure: true` in the `sessions.Options`. The site should also enforce HTTPS at the reverse proxy level.

---

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation, Qwen3.6 used for detection

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
