### PR TITLE
Add default retention to all asynq tasks.

### DIFF
--- a/pkg/async/task/client.go
+++ b/pkg/async/task/client.go
@@ -4,11 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
+)
+
+const (
+	defaultTaskRetention = 14 * 24 * time.Hour // only with retention a task will be stored in completed tasks
 )
 
 var (
@@ -141,8 +146,15 @@ func (c *Client) NewTask(payload TaskPayload, additionalOpts ...asynq.Option) (*
 
 	var (
 		opts = append(c.opts, asynq.TaskID(taskId))
-		task = asynq.NewTask(string(payload.Type()), encoded, append(opts, additionalOpts...)...)
 	)
+
+	if !slices.ContainsFunc(additionalOpts, func(opt asynq.Option) bool {
+		return opt.Type() == asynq.RetentionOpt
+	}) {
+		opts = append(opts, asynq.Retention(defaultTaskRetention))
+	}
+
+	task := asynq.NewTask(string(payload.Type()), encoded, append(opts, additionalOpts...)...)
 
 	taskInfo, err := c.client.Enqueue(task)
 

--- a/pkg/repository/ip.go
+++ b/pkg/repository/ip.go
@@ -185,7 +185,7 @@ func (r *ipRepository) delete(ctx context.Context, e *metal.IP) error {
 		return err
 	}
 
-	r.s.log.Info("ip delete queued", "info", info)
+	r.s.log.Info("ip delete enqueued", "info", info)
 
 	return nil
 }

--- a/pkg/repository/machine-create.go
+++ b/pkg/repository/machine-create.go
@@ -265,7 +265,8 @@ func (r *machineRepository) rollback(ctx context.Context, rollbackEntities *roll
 				r.s.log.Error("unable to start task to delete ip", "error", err)
 				continue
 			}
-			r.s.log.Info("ip delete queued", "info", info)
+
+			r.s.log.Info("ip delete enqueued", "info", info)
 		} else {
 			metalIP, err := r.s.ds.IP().Find(ctx, queries.IpFilter(&apiv2.IPQuery{Uuid: &ip.AllocationUUID}))
 			if err != nil {

--- a/pkg/repository/machine.go
+++ b/pkg/repository/machine.go
@@ -203,7 +203,7 @@ func (r *machineRepository) delete(ctx context.Context, m *metal.Machine) error 
 		return err
 	}
 
-	r.s.log.Info("machine delete queued", "info", info)
+	r.s.log.Info("machine delete enqueued", "info", info)
 
 	return nil
 }
@@ -1181,7 +1181,6 @@ func (r *machineRepository) MachineBMCCommand(ctx context.Context, machineUUID, 
 	},
 		asynq.Timeout(time.Minute),
 		asynq.MaxRetry(0),
-		asynq.Retention(30*24*time.Hour), // Only with retention a task will be stored in completed tasks
 	)
 	if err != nil {
 		return err
@@ -1249,7 +1248,6 @@ func (r *machineRepository) Wait(ctx context.Context, req *infrav2.BootServiceWa
 }
 
 func (r *machineRepository) WaitForBMCCommand(ctx context.Context, req *infrav2.WaitForBMCCommandRequest, stream *connect.ServerStream[infrav2.WaitForBMCCommandResponse]) error {
-
 	// Stream messages to client
 	cmdChan := r.s.queue.WaitMachineCommand(ctx, req.Partition)
 

--- a/pkg/repository/network.go
+++ b/pkg/repository/network.go
@@ -51,7 +51,7 @@ func (r *networkRepository) delete(ctx context.Context, nw *metal.Network) error
 		return err
 	}
 
-	r.s.log.Info("network delete queued", "info", info)
+	r.s.log.Info("network delete enqueued", "info", info)
 
 	return nil
 }


### PR DESCRIPTION
## Description

Extracted from #197. 

This way we ensure that all tasks are persisted in the backend for 14 days until they vanish. We can discuss if this is too long or not, but I think we should persist them in general to be able to see if something went wrong.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
