### PR TITLE
Reserved is now migrated to tainted

### DIFF
--- a/pkg/db/metal/machine.go
+++ b/pkg/db/metal/machine.go
@@ -72,9 +72,6 @@ type MState string
 const (
 	// AvailableState describes a machine state where a machine is available for an allocation
 	AvailableState MState = ""
-	// ReservedState describes a machine state where a machine is not being considered for random allocation
-	// Deprecated: use TaintedState instead
-	ReservedState MState = "RESERVED"
 	// TaintedState describes a machine state where a machine is not being considered for random allocation
 	TaintedState MState = "TAINTED"
 	// LockedState describes a machine state where a machine cannot be deleted or allocated anymore
@@ -406,7 +403,7 @@ func ToAPIV2MachineStatus(state MState) (apiv2.MachineState, error) {
 	switch state {
 	case AvailableState:
 		return apiv2.MachineState_MACHINE_STATE_AVAILABLE, nil
-	case ReservedState, TaintedState:
+	case TaintedState:
 		return apiv2.MachineState_MACHINE_STATE_TAINTED, nil
 	case LockedState:
 		return apiv2.MachineState_MACHINE_STATE_LOCKED, nil

--- a/pkg/repository/machine-create.go
+++ b/pkg/repository/machine-create.go
@@ -325,7 +325,7 @@ func (r *machineRepository) findWaitingMachine(ctx context.Context, partition, p
 	candidates, err := r.s.ds.Machine().List(ctx, queries.MachineFilter(&apiv2.MachineQuery{
 		Partition:    &partition,
 		Size:         &size,
-		State:        apiv2.MachineState_MACHINE_STATE_AVAILABLE.Enum(), // Machines which are locked or reserved are not considered
+		State:        apiv2.MachineState_MACHINE_STATE_AVAILABLE.Enum(), // Machines which are locked or tainted are not considered
 		Waiting:      new(true),
 		Preallocated: new(false),
 		NotAllocated: new(true),

--- a/pkg/repository/machine-validation.go
+++ b/pkg/repository/machine-validation.go
@@ -55,8 +55,8 @@ func (r *machineRepository) validateCreate(ctx context.Context, req *apiv2.Machi
 		switch m.State.Value {
 		case metal.LockedState:
 			return fmt.Errorf("machine %s is %s", *req.Uuid, m.State.Value)
-		case metal.AvailableState, metal.ReservedState:
-			// machines which are reserved can be allocated by specifying the uuid,
+		case metal.AvailableState, metal.TaintedState:
+			// machines which are tainted can be allocated by specifying the uuid,
 			// but they will not be considered for random allocation
 		}
 		if !m.Waiting {

--- a/pkg/service/admin/partition/partition-service_test.go
+++ b/pkg/service/admin/partition/partition-service_test.go
@@ -342,10 +342,10 @@ func Test_partitionServiceServer_Update(t *testing.T) {
 			wantErr: nil,
 			want: &adminv2.PartitionServiceUpdateResponse{
 				Partition: &apiv2.Partition{
-					Id:                   "partition-4",
-					Meta:                 &apiv2.Meta{Generation: 1},
-					BootConfiguration:    &apiv2.PartitionBootConfiguration{ImageUrl: validURL, KernelUrl: validURL},
-					Description:          "",
+					Id:                "partition-4",
+					Meta:              &apiv2.Meta{Generation: 1},
+					BootConfiguration: &apiv2.PartitionBootConfiguration{ImageUrl: validURL, KernelUrl: validURL},
+					Description:       "",
 				},
 			},
 		},
@@ -732,7 +732,7 @@ func Test_partitionServiceServer_Capacity(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:    "reserved machine does not count as free",
+			name:    "tainted machine does not count as free",
 			request: &adminv2.PartitionServiceCapacityRequest{Id: &partition1},
 			scenarioModFn: func(spec *sc.DatacenterSpec) {
 				spec.Machines = []*sc.MachineWithLiveliness{


### PR DESCRIPTION
## Description

With metal-api v0.44.0 Reserved was migrated to Tainted, remove leftovers here as well.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
