### PR TITLE
Report correct valkey version

### DIFF
--- a/pkg/service/api/api-services.go
+++ b/pkg/service/api/api-services.go
@@ -53,7 +53,7 @@ type Config struct {
 	TokenStore         tokencommon.TokenStore
 	CertStore          certs.CertStore
 	AuditSearchBackend auditing.Auditing
-	Redis              valkey.Client
+	Valkey             valkey.Client
 	AuditBackends      []auditing.Auditing
 	HeadscaleClient    *headscale.Client
 
@@ -108,7 +108,7 @@ func ApiServices(ctx context.Context, cfg Config) (token.TokenService, error) {
 		Ipam:                cfg.IpamClient,
 		TenantClient:        cfg.TenantClient,
 		Datastore:           cfg.Datastore,
-		Redis:               cfg.Redis,
+		Valkey:              cfg.Valkey,
 		Headscale:           cfg.HeadscaleClient,
 		AuditBackends:       cfg.AuditBackends,
 		TaskClient:          cfg.Repository.Task(),

--- a/pkg/service/api/health/health-service.go
+++ b/pkg/service/api/health/health-service.go
@@ -33,7 +33,7 @@ type Config struct {
 	Ctx                 context.Context
 	HealthcheckInterval time.Duration
 	Ipam                ipamv1connect.IpamServiceClient
-	Redis               valkeygo.Client
+	Valkey              valkeygo.Client
 	TenantClient        tenant.Client
 	Headscale           *headscale.Client
 	TaskClient          *task.Client
@@ -65,8 +65,8 @@ func New(c Config) (apiv2connect.HealthServiceHandler, error) {
 	if c.Datastore != nil {
 		checkers = append(checkers, &rethinkdbHealthChecker{ds: c.Datastore})
 	}
-	if c.Redis != nil {
-		checkers = append(checkers, &redisHealthChecker{redis: c.Redis})
+	if c.Valkey != nil {
+		checkers = append(checkers, &valkeyHealthChecker{valkey: c.Valkey})
 	}
 	if c.Headscale != nil {
 		checkers = append(checkers, &vpnHealthChecker{client: c.Headscale})

--- a/pkg/service/api/health/valkey-checker.go
+++ b/pkg/service/api/health/valkey-checker.go
@@ -9,12 +9,12 @@ import (
 	valkeygo "github.com/valkey-io/valkey-go"
 )
 
-type redisHealthChecker struct {
-	redis valkeygo.Client
+type valkeyHealthChecker struct {
+	valkey valkeygo.Client
 }
 
-func (h *redisHealthChecker) Health(ctx context.Context) *apiv2.HealthStatus {
-	res, err := h.redis.Do(ctx, h.redis.B().Info().Section("server").Section("server_version").Build()).ToString()
+func (h *valkeyHealthChecker) Health(ctx context.Context) *apiv2.HealthStatus {
+	res, err := h.valkey.Do(ctx, h.valkey.B().Info().Section("server").Section("server_version").Build()).ToString()
 
 	var (
 		status  = apiv2.ServiceStatus_SERVICE_STATUS_HEALTHY
@@ -26,7 +26,7 @@ func (h *redisHealthChecker) Health(ctx context.Context) *apiv2.HealthStatus {
 		message = err.Error()
 	} else {
 		info := verbatimStringToMap(res)
-		message = fmt.Sprintf("connected to redis service %q version %q", info["server_name"], info["redis_version"])
+		message = fmt.Sprintf("connected to %q version %q", info["server_name"], info["valkey_version"])
 	}
 
 	return &apiv2.HealthStatus{

--- a/pkg/service/api/health/vpn-checker.go
+++ b/pkg/service/api/health/vpn-checker.go
@@ -13,13 +13,11 @@ type vpnHealthChecker struct {
 }
 
 func (h *vpnHealthChecker) Health(ctx context.Context) *apiv2.HealthStatus {
-	res, err := h.client.Health(ctx, &headscalev1.HealthRequest{})
-
 	var (
 		status  = apiv2.ServiceStatus_SERVICE_STATUS_HEALTHY
 		message string
 	)
-
+	res, err := h.client.Health(ctx, &headscalev1.HealthRequest{})
 	if err != nil {
 		status = apiv2.ServiceStatus_SERVICE_STATUS_UNHEALTHY
 		message = err.Error()

--- a/pkg/service/services.go
+++ b/pkg/service/services.go
@@ -183,7 +183,7 @@ func New(ctx context.Context, log *slog.Logger, c Config) (*http.ServeMux, error
 		TokenStore:         tokenStore,
 		CertStore:          certStore,
 		AuditSearchBackend: c.AuditSearchBackend,
-		Redis:              c.RedisConfig.ComponentClient,
+		Valkey:             c.RedisConfig.ComponentClient,
 		ServerHttpURL:      c.ServerHttpURL,
 		ProviderTenant:     c.ProviderTenant,
 		AuditBackends:      c.AuditBackends,


### PR DESCRIPTION
## Description

health of valkey is actually reported wrong:

```
$ metalctlv2 health 
   NAME              MESSAGE                                                                                     
✔  ipam              connected to ipam service version "tags/v1.15.1-0-gec106e7"                                 
✔  rethinkdb         connected to rethinkdb version "rethinkdb 2.4.4~0bookworm (x86_64-linux-gnu) (GCC 12.2.0)"  
✔  tenant-apiserver  connected to tenant-apiserver service version "tags/v0.1.0-0-g3c71387"                      
✔  audit             all audit backends healthy                                                                  
✔  redis             connected to redis service "valkey" version "7.2.4"                                         
✔  tasks             connected to tasks server       
```

Now the actual server type (redis/valkey) and the correct version is returned:

```
metalctlv2 health 
   NAME              MESSAGE                                                                                     
✔  ipam              connected to ipam service version "tags/v1.15.1-0-gec106e7"                                 
✔  rethinkdb         connected to rethinkdb version "rethinkdb 2.4.4~0bookworm (x86_64-linux-gnu) (GCC 12.2.0)"  
✔  tenant-apiserver  connected to tenant-apiserver service version "tags/v0.1.0-0-g3c71387"                      
✔  audit             all audit backends healthy                                                                  
✔  redis             connected to "valkey" version "9.1.0"                                                       
✔  tasks             connected to tasks server  
```

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
