### PR TITLE
Extend token store model to contain `labels` and `updated_at`

### DIFF
--- a/pkg/token/token-store-model.go
+++ b/pkg/token/token-store-model.go
@@ -32,6 +32,10 @@ type token struct {
 	InfraRole *string `json:"infra_role,omitempty"`
 	// MachineRoles associates a machine uuid with the corresponding role of the token owner
 	MachineRoles map[string]string `json:"machine_roles,omitempty"`
+	// Labels holds labels associated with the token
+	Labels map[string]string `json:"labels,omitempty"`
+	// UpdatedAt gives the date when this token was updated
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 type methodPermission struct {
@@ -43,25 +47,29 @@ type methodPermission struct {
 }
 
 func toInternal(t *apiv2.Token) *token {
-	var permissions []methodPermission
+	var (
+		permissions []methodPermission
+
+		projectRoles = map[string]string{}
+		tenantRoles  = map[string]string{}
+
+		expires   *time.Time
+		issuedAt  *time.Time
+		updatedAt *time.Time
+
+		adminRole    *string
+		infraRole    *string
+		machineRoles = map[string]string{}
+
+		labels map[string]string
+	)
+
 	for _, p := range t.Permissions {
 		permissions = append(permissions, methodPermission{
 			Subject: p.Subject,
 			Methods: p.Methods,
 		})
 	}
-
-	var (
-		projectRoles = map[string]string{}
-		tenantRoles  = map[string]string{}
-
-		expires  *time.Time
-		issuedAt *time.Time
-
-		adminRole    *string
-		infraRole    *string
-		machineRoles = map[string]string{}
-	)
 
 	if t.Expires != nil {
 		expires = new(t.Expires.AsTime())
@@ -89,6 +97,16 @@ func toInternal(t *apiv2.Token) *token {
 		machineRoles[id] = role.String()
 	}
 
+	if t.Meta != nil {
+		if t.Meta.UpdatedAt != nil {
+			updatedAt = new(t.Meta.UpdatedAt.AsTime())
+		}
+
+		if t.Meta.Labels != nil {
+			labels = t.Meta.Labels.Labels
+		}
+	}
+
 	return &token{
 		Uuid:         t.Uuid,
 		User:         t.User,
@@ -96,17 +114,34 @@ func toInternal(t *apiv2.Token) *token {
 		Permissions:  permissions,
 		Expires:      expires,
 		IssuedAt:     issuedAt,
+		UpdatedAt:    updatedAt,
 		TokenType:    int32(t.TokenType),
 		ProjectRoles: projectRoles,
 		TenantRoles:  tenantRoles,
 		AdminRole:    adminRole,
 		InfraRole:    infraRole,
 		MachineRoles: machineRoles,
+		Labels:       labels,
 	}
 }
 
 func toExternal(t *token) *apiv2.Token {
-	var permissions []*apiv2.MethodPermission
+
+	var (
+		permissions []*apiv2.MethodPermission
+
+		projectRoles = map[string]apiv2.ProjectRole{}
+		tenantRoles  = map[string]apiv2.TenantRole{}
+
+		expires   *timestamppb.Timestamp
+		issuedAt  *timestamppb.Timestamp
+		updatedAt *timestamppb.Timestamp
+
+		adminRole    *apiv2.AdminRole
+		infraRole    *apiv2.InfraRole
+		machineRoles = map[string]apiv2.MachineRole{}
+	)
+
 	for _, p := range t.Permissions {
 		permissions = append(permissions, &apiv2.MethodPermission{
 			Subject: p.Subject,
@@ -114,23 +149,14 @@ func toExternal(t *token) *apiv2.Token {
 		})
 	}
 
-	var (
-		projectRoles = map[string]apiv2.ProjectRole{}
-		tenantRoles  = map[string]apiv2.TenantRole{}
-
-		expires  *timestamppb.Timestamp
-		issuedAt *timestamppb.Timestamp
-
-		adminRole    *apiv2.AdminRole
-		infraRole    *apiv2.InfraRole
-		machineRoles = map[string]apiv2.MachineRole{}
-	)
-
 	if t.Expires != nil {
 		expires = timestamppb.New(*t.Expires)
 	}
 	if t.IssuedAt != nil {
 		issuedAt = timestamppb.New(*t.IssuedAt)
+	}
+	if t.UpdatedAt != nil {
+		updatedAt = timestamppb.New(*t.UpdatedAt)
 	}
 
 	for id, role := range t.ProjectRoles {
@@ -152,7 +178,19 @@ func toExternal(t *token) *apiv2.Token {
 		machineRoles[id] = apiv2.MachineRole(apiv2.MachineRole_value[role])
 	}
 
+	meta := &apiv2.Meta{
+		CreatedAt: issuedAt,
+		UpdatedAt: updatedAt,
+	}
+
+	if t.Labels != nil {
+		meta.Labels = &apiv2.Labels{
+			Labels: t.Labels,
+		}
+	}
+
 	return &apiv2.Token{
+		Meta:         meta,
 		Uuid:         t.Uuid,
 		User:         t.User,
 		Description:  t.Description,

--- a/pkg/token/token-store_test.go
+++ b/pkg/token/token-store_test.go
@@ -6,14 +6,17 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestRedisStore(t *testing.T) {
+func TestTokenStore(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	s := miniredis.RunT(t)
@@ -55,7 +58,7 @@ func TestRedisStore(t *testing.T) {
 	require.Nil(t, tok)
 }
 
-func TestRedisStoreSetAndGet(t *testing.T) {
+func TestTokenStoreSetAndGet(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	s := miniredis.RunT(t)
@@ -66,6 +69,13 @@ func TestRedisStoreSetAndGet(t *testing.T) {
 	now := time.Now()
 
 	inTok := &apiv2.Token{
+		Meta: &apiv2.Meta{
+			Labels: &apiv2.Labels{
+				Labels: map[string]string{
+					"a": "b",
+				},
+			},
+		},
 		Uuid:        "bd21fe60-047c-45aa-812d-adc44e098a38",
 		User:        "john@doe.com",
 		Description: "abc",
@@ -100,5 +110,14 @@ func TestRedisStoreSetAndGet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, outTok)
 
-	assert.Equal(t, inTok, outTok)
+	if diff := cmp.Diff(
+		outTok, inTok,
+		protocmp.Transform(),
+		protocmp.IgnoreFields(
+			&apiv2.Meta{}, "created_at",
+		),
+		cmpopts.IgnoreUnexported(),
+	); diff != "" {
+		t.Errorf("diff: %s", diff)
+	}
 }


### PR DESCRIPTION
## Description

The way too large https://github.com/metal-stack/metal-apiserver/pull/208 must be chopped into smaller, understandable pieces.

This PR extends the store token model with the new `labels` and `updated_at` fields.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
