### PR TITLE
Move max token expiration to certs package.

### DIFF
--- a/pkg/auth/jwt-token-cert-rotation_test.go
+++ b/pkg/auth/jwt-token-cert-rotation_test.go
@@ -19,18 +19,18 @@ import (
 
 func Test_jwt_cert_rotation(t *testing.T) {
 	t.Parallel()
-	oldMaxExpiration := token.MaxExpiration
+	oldMaxExpiration := certs.MaxTokenExpiration
 	oldDefaultExpiration := token.DefaultExpiration
 
-	token.MaxExpiration = 5 * time.Second
+	certs.MaxTokenExpiration = 5 * time.Second
 	token.DefaultExpiration = 5 * time.Second
 	defer func() {
-		token.MaxExpiration = oldMaxExpiration
+		certs.MaxTokenExpiration = oldMaxExpiration
 		token.DefaultExpiration = oldDefaultExpiration
 	}()
 	renewCertBeforeExpiration := 7 * time.Second
 
-	t.Logf("token lifetime: %s, certificate lifetime: %s, issue new signing certificate after: %s", token.DefaultExpiration, 2*token.MaxExpiration, 2*token.MaxExpiration-renewCertBeforeExpiration)
+	t.Logf("token lifetime: %s, certificate lifetime: %s, issue new signing certificate after: %s", token.DefaultExpiration, 2*certs.MaxTokenExpiration, 2*certs.MaxTokenExpiration-renewCertBeforeExpiration)
 
 	s := miniredis.RunT(t)
 	c := redis.NewClient(&redis.Options{Addr: s.Addr()})

--- a/pkg/certs/certs-store.go
+++ b/pkg/certs/certs-store.go
@@ -17,12 +17,22 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v3/jwk"
-	"github.com/metal-stack/metal-apiserver/pkg/token"
 	"github.com/redis/go-redis/v9"
+)
+
+var (
+	// MaxTokenExpiration defines the maximum lifetime of a token (which depends on the root cert expiration)
+	MaxTokenExpiration = 365 * 24 * time.Hour
 )
 
 const (
 	prefix = "certstore_"
+
+	// defaultRenewalThreshold is the default duration when a new root certificate gets issued before it expires.
+	// e.g. 365 days max token lifetime = 730 days root cert expiration, renewal 90 days before expiration = renewal at day 640.
+	//
+	// the renewal process is triggered when the root certificate is retrieved from the store.
+	defaultRenewalThreshold = 90 * 24 * time.Hour
 )
 
 type Config struct {
@@ -59,10 +69,11 @@ func matchPublic() string {
 }
 
 func NewRedisStore(c *Config) CertStore {
-	renewCertBeforeExpiration := 90 * 24 * time.Hour
+	renewCertBeforeExpiration := defaultRenewalThreshold
 	if c.RenewCertBeforeExpiration != nil {
 		renewCertBeforeExpiration = *c.RenewCertBeforeExpiration
 	}
+
 	return &redisStore{
 		client:                    c.RedisClient,
 		renewCertBeforeExpiration: renewCertBeforeExpiration,
@@ -105,7 +116,7 @@ func (r *redisStore) LatestPrivate(ctx context.Context) (*ecdsa.PrivateKey, erro
 func (r *redisStore) setNewCert(ctx context.Context) (*ecdsa.PrivateKey, error) {
 	now := time.Now()
 
-	cert, privKey, rawBytes, err := createRootCertificate("metal-stack", now, now.Add(2*token.MaxExpiration))
+	cert, privKey, rawBytes, err := createRootCertificate("metal-stack", now, now.Add(2*MaxTokenExpiration))
 	if err != nil {
 		return nil, fmt.Errorf("unable to create certificate: %w", err)
 	}

--- a/pkg/certs/certs-store_test.go
+++ b/pkg/certs/certs-store_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/metal-stack/metal-apiserver/pkg/certs"
-	"github.com/metal-stack/metal-apiserver/pkg/token"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +17,7 @@ func Test_redisStore(t *testing.T) {
 		s     = miniredis.RunT(t)
 		c     = redis.NewClient(&redis.Options{Addr: s.Addr()})
 		store = certs.NewRedisStore(&certs.Config{
-			RenewCertBeforeExpiration: new(4 * token.MaxExpiration),
+			RenewCertBeforeExpiration: new(4 * certs.MaxTokenExpiration),
 			RedisClient:               c,
 		})
 	)

--- a/pkg/service/api/token/token-service.go
+++ b/pkg/service/api/token/token-service.go
@@ -256,8 +256,8 @@ func (t *tokenService) CreateTokenForUser(ctx context.Context, user *string, req
 		return nil, errorutil.Unauthenticated("no token found in request")
 	}
 
-	if req.Expires.AsDuration() > tokenutil.MaxExpiration {
-		return nil, fmt.Errorf("requested expiration duration: %q exceeds max expiration: %q", req.Expires.AsDuration(), tokenutil.MaxExpiration)
+	if req.Expires.AsDuration() > certs.MaxTokenExpiration {
+		return nil, fmt.Errorf("requested expiration duration: %q exceeds max expiration: %q", req.Expires.AsDuration(), certs.MaxTokenExpiration)
 	}
 
 	projectsAndTenants, err := t.projectsAndTenantsGetter(ctx, token.GetUser())

--- a/pkg/token/jwt.go
+++ b/pkg/token/jwt.go
@@ -13,12 +13,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
+	"github.com/metal-stack/metal-apiserver/pkg/certs"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
 	DefaultExpiration = time.Hour * 8
-	MaxExpiration     = 365 * 24 * time.Hour
 )
 
 type (
@@ -35,8 +35,8 @@ func NewJWT(tokenType apiv2.TokenType, subject, issuer string, expires time.Dura
 	if expires == 0 {
 		expires = DefaultExpiration
 	}
-	if expires > MaxExpiration {
-		return "", nil, fmt.Errorf("expires: %q exceeds maximum: %q", expires, MaxExpiration)
+	if expires > certs.MaxTokenExpiration {
+		return "", nil, fmt.Errorf("expires: %q exceeds maximum: %q", expires, certs.MaxTokenExpiration)
 	}
 
 	id, err := uuid.NewV7()


### PR DESCRIPTION
## Description

The way too large https://github.com/metal-stack/metal-apiserver/pull/208 must be chopped into smaller, understandable pieces.

This removes the dependency of the `certs` package on the `token` package, which will then allow to refactor the token packages. Also it makes sense because the max token expiration is actually defined by the master cert expiration.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
