### PR TITLE
Return proto errors from token store and improve errors in general

### DIFF
--- a/pkg/auth/authenticator-interceptor.go
+++ b/pkg/auth/authenticator-interceptor.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -176,11 +175,11 @@ func (o *auth) extractAndValidateJWTToken(ctx context.Context, jwtTokenfunc func
 
 	t, err := o.tokenStore.Get(ctx, claim.Subject, claim.ID)
 	if err != nil {
-		if errors.Is(err, token.ErrTokenNotFound) {
+		if errorutil.IsNotFound(err) {
 			return nil, errorutil.Unauthenticated("token was revoked")
 		}
 
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 	return t, nil
 }

--- a/pkg/service/admin/token/token-service.go
+++ b/pkg/service/admin/token/token-service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/metal-stack/api/go/errorutil"
 	adminv2 "github.com/metal-stack/api/go/metalstack/admin/v2"
 	"github.com/metal-stack/api/go/metalstack/admin/v2/adminv2connect"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
@@ -44,12 +43,12 @@ func (t *tokenService) List(ctx context.Context, req *adminv2.TokenServiceListRe
 	if req.Query != nil && req.Query.User != nil {
 		tokens, err = t.tokenstore.List(ctx, *req.Query.User)
 		if err != nil {
-			return nil, errorutil.NewInternal(err)
+			return nil, err
 		}
 	} else {
 		tokens, err = t.tokenstore.AdminList(ctx)
 		if err != nil {
-			return nil, errorutil.NewInternal(err)
+			return nil, err
 		}
 	}
 
@@ -61,7 +60,7 @@ func (t *tokenService) List(ctx context.Context, req *adminv2.TokenServiceListRe
 func (t *tokenService) Revoke(ctx context.Context, req *adminv2.TokenServiceRevokeRequest) (*adminv2.TokenServiceRevokeResponse, error) {
 	err := t.tokenstore.Revoke(ctx, req.User, req.Uuid)
 	if err != nil {
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	return &adminv2.TokenServiceRevokeResponse{}, nil

--- a/pkg/service/api/token/token-service.go
+++ b/pkg/service/api/token/token-service.go
@@ -92,7 +92,7 @@ func (t *tokenService) CreateUserTokenWithoutPermissionCheck(ctx context.Context
 
 	err = t.tokens.Set(ctx, token)
 	if err != nil {
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	return &apiv2.TokenServiceCreateResponse{
@@ -129,7 +129,7 @@ func (t *tokenService) CreateApiTokenWithoutPermissionCheck(ctx context.Context,
 
 	err = t.tokens.Set(ctx, token)
 	if err != nil {
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	return &apiv2.TokenServiceCreateResponse{
@@ -147,10 +147,7 @@ func (t *tokenService) Get(ctx context.Context, rq *apiv2.TokenServiceGetRequest
 
 	res, err := t.tokens.Get(ctx, token.User, rq.Uuid)
 	if err != nil {
-		if errors.Is(err, tokenutil.ErrTokenNotFound) {
-			return nil, errorutil.NotFound("token not found")
-		}
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	return &apiv2.TokenServiceGetResponse{
@@ -204,10 +201,7 @@ func (t *tokenService) Update(ctx context.Context, req *apiv2.TokenServiceUpdate
 
 	tokenToUpdate, err := t.tokens.Get(ctx, token.User, req.Uuid)
 	if err != nil {
-		if errors.Is(err, tokenutil.ErrTokenNotFound) {
-			return nil, errorutil.NotFound("token not found")
-		}
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	if tokenToUpdate.TokenType != apiv2.TokenType_TOKEN_TYPE_API {
@@ -232,7 +226,7 @@ func (t *tokenService) Update(ctx context.Context, req *apiv2.TokenServiceUpdate
 
 	err = t.tokens.Set(ctx, tokenToUpdate)
 	if err != nil {
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	return &apiv2.TokenServiceUpdateResponse{
@@ -345,7 +339,7 @@ func (t *tokenService) CreateTokenForUser(ctx context.Context, user *string, req
 
 	err = t.tokens.Set(ctx, token)
 	if err != nil {
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	resp := &apiv2.TokenServiceCreateResponse{
@@ -365,7 +359,7 @@ func (t *tokenService) List(ctx context.Context, _ *apiv2.TokenServiceListReques
 
 	tokens, err := t.tokens.List(ctx, token.User)
 	if err != nil {
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	return &apiv2.TokenServiceListResponse{
@@ -382,7 +376,7 @@ func (t *tokenService) Revoke(ctx context.Context, rq *apiv2.TokenServiceRevokeR
 
 	err := t.tokens.Revoke(ctx, token.User, rq.Uuid)
 	if err != nil {
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	return &apiv2.TokenServiceRevokeResponse{}, nil
@@ -396,10 +390,7 @@ func (t *tokenService) Refresh(ctx context.Context, _ *apiv2.TokenServiceRefresh
 
 	oldtoken, err := t.tokens.Get(ctx, token.User, token.Uuid)
 	if err != nil {
-		if errors.Is(err, tokenutil.ErrTokenNotFound) {
-			return nil, errorutil.NotFound("token not found")
-		}
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	// we first copy the token permission from the old token
@@ -466,7 +457,7 @@ func (t *tokenService) Refresh(ctx context.Context, _ *apiv2.TokenServiceRefresh
 
 	err = t.tokens.Set(ctx, newToken)
 	if err != nil {
-		return nil, errorutil.NewInternal(err)
+		return nil, err
 	}
 
 	return &apiv2.TokenServiceRefreshResponse{

--- a/pkg/token/token-store.go
+++ b/pkg/token/token-store.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
+	"github.com/metal-stack/api/go/errorutil"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
 	"github.com/redis/go-redis/v9"
 )
@@ -15,10 +15,6 @@ import (
 const (
 	separator = ":"
 	prefix    = "tokenstore_"
-)
-
-var (
-	ErrTokenNotFound = redis.Nil
 )
 
 type TokenStore interface {
@@ -49,9 +45,20 @@ func NewRedisStore(client *redis.Client) TokenStore {
 }
 
 func (r *redisStore) Set(ctx context.Context, token *apiv2.Token) error {
+	if token.Meta == nil {
+		token.Meta = &apiv2.Meta{}
+	}
+
+	// TODO: implement optimistic locking. documentation of clients advise to use a small, atomic lua script for this.
+	// token.Meta.UpdatedAt = timestamppb.Now()
+
+	if token.Meta != nil && token.Meta.UpdatedAt != nil {
+		return errorutil.InvalidArgument("optimistic locking is not yet implemented, please do not provide updated_at")
+	}
+
 	encoded, err := json.Marshal(toInternal(token))
 	if err != nil {
-		return fmt.Errorf("unable to encode token: %w", err)
+		return errorutil.Internal("unable to encode token: %w", err)
 	}
 
 	_, err = r.client.Set(ctx, key(token.User, token.Uuid), string(encoded), time.Until(token.Expires.AsTime())).Result()
@@ -65,13 +72,17 @@ func (r *redisStore) Set(ctx context.Context, token *apiv2.Token) error {
 func (r *redisStore) Get(ctx context.Context, userid, tokenid string) (*apiv2.Token, error) {
 	encoded, err := r.client.Get(ctx, key(userid, tokenid)).Result()
 	if err != nil {
-		return nil, err
+		if errors.Is(err, redis.Nil) {
+			return nil, errorutil.NotFound("token not found")
+		}
+
+		return nil, errorutil.Internal("unable to get token: %w", err)
 	}
 
 	var t token
 	err = json.Unmarshal([]byte(encoded), &t)
 	if err != nil {
-		return nil, err
+		return nil, errorutil.Internal("unable to decode token: %w", err)
 	}
 
 	return toExternal(&t), nil
@@ -86,19 +97,19 @@ func (r *redisStore) List(ctx context.Context, userid string) ([]*apiv2.Token, e
 	for iter.Next(ctx) {
 		encoded, err := r.client.Get(ctx, iter.Val()).Result()
 		if err != nil {
-			return nil, err
+			return nil, errorutil.Internal("unable to get token: %w", err)
 		}
 
 		var t token
 		err = json.Unmarshal([]byte(encoded), &t)
 		if err != nil {
-			return nil, err
+			return nil, errorutil.Internal("unable to decode token: %w", err)
 		}
 
 		res = append(res, toExternal(&t))
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return nil, errorutil.Internal("unable to iterate tokens: %w", err)
 	}
 
 	return res, nil
@@ -113,27 +124,35 @@ func (r *redisStore) AdminList(ctx context.Context) ([]*apiv2.Token, error) {
 	for iter.Next(ctx) {
 		encoded, err := r.client.Get(ctx, iter.Val()).Result()
 		if err != nil {
-			return nil, err
+			return nil, errorutil.Internal("unable to get token: %w", err)
 		}
 
 		var t token
 		err = json.Unmarshal([]byte(encoded), &t)
 		if err != nil {
-			return nil, err
+			return nil, errorutil.Internal("unable to decode token: %w", err)
 		}
 
 		res = append(res, toExternal(&t))
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return nil, errorutil.Internal("unable to iterate tokens: %w", err)
 	}
 
 	return res, nil
 }
 
 func (r *redisStore) Revoke(ctx context.Context, userid, tokenid string) error {
-	_, err := r.client.Del(ctx, key(userid, tokenid)).Result()
-	return err
+	res, err := r.client.Del(ctx, key(userid, tokenid)).Result()
+	if err != nil {
+		return errorutil.Internal("unable to revoke token: %w", err)
+	}
+
+	if res == 0 {
+		return errorutil.NotFound("token not found")
+	}
+
+	return nil
 }
 
 func (r *redisStore) Migrate(ctx context.Context, log *slog.Logger) error {

--- a/pkg/token/token-store_test.go
+++ b/pkg/token/token-store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/metal-stack/api/go/errorutil"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,11 @@ func TestTokenStore(t *testing.T) {
 
 	err = store.Revoke(ctx, johnDoeToken.User, johnDoeToken.Uuid)
 	require.NoError(t, err)
+
+	err = store.Revoke(ctx, johnDoeToken.User, "1234")
+	if diff := cmp.Diff(errorutil.NotFound("token not found"), err, errorutil.ErrorStringComparer()); diff != "" {
+		t.Errorf("error diff (+got -want):\n %s", diff)
+	}
 
 	tok, err = store.Get(ctx, johnDoeToken.User, johnDoeToken.Uuid)
 	require.Error(t, err)


### PR DESCRIPTION
## Description

The way too large https://github.com/metal-stack/metal-apiserver/pull/208 must be chopped into smaller, understandable pieces.

Before this PR, the `UpdateMeta` fields were completely neglected by the token store. Now that we pass labels in the update meta for tokens, clients are also tempted to send `UpdatedAt` and want to prevent concurrent modification. This is, however, not implemented and can be confusing for clients when it does not work as expected. Therefore, the token store will now return an error when clients specify `UpdatedAt` in the update meta.

In order to prevent consumers of the token store to check for `redis.Nil` and in order to better distinguish different errors that can occur in the token store, the store now returns proto errors. This would also allow to return `Aborted` in case we start implementing optimistic locking for token updates.

Also, token revocation was improved: It was possible to always call it and it never failed even when there was no token present anymore to revoke. Now, it returns `NotFound` in case no token was revoked.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
