### PR TITLE
Add more authorizer tests to ensure machine scoping works

### DIFF
--- a/pkg/repository/audit.go
+++ b/pkg/repository/audit.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"time"
 
-	"connectrpc.com/connect"
+	"github.com/metal-stack/api/go/errorutil"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
 	"github.com/metal-stack/metal-apiserver/pkg/repository/api"
 	"github.com/metal-stack/metal-lib/auditing"
@@ -53,7 +53,7 @@ func (a *auditRepository) list(ctx context.Context, query *apiv2.AuditQuery) ([]
 	}
 
 	if from.After(to) {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid time window, from must be before to"))
+		return nil, errorutil.InvalidArgument("invalid time window, from must be before to")
 	}
 
 	var code *int
@@ -82,7 +82,7 @@ func (a *auditRepository) list(ctx context.Context, query *apiv2.AuditQuery) ([]
 
 	entries, err := a.c.Search(ctx, filter)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error searching audit backend: %w", err))
+		return nil, errorutil.Internal("error searching audit backend: %w", err)
 	}
 
 	sort.Slice(entries, func(i, j int) bool {

--- a/pkg/request/authorize.go
+++ b/pkg/request/authorize.go
@@ -2,11 +2,11 @@ package request
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
+	"slices"
 
 	"connectrpc.com/connect"
+	"github.com/metal-stack/api/go/errorutil"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
 	"github.com/metal-stack/api/go/permissions"
 	"github.com/metal-stack/metal-apiserver/pkg/repository/api"
@@ -42,7 +42,7 @@ func (a *authorizer) Authorize(ctx context.Context, token *apiv2.Token, req conn
 		subject string
 	)
 	if req == nil {
-		return connect.NewError(connect.CodeInternal, fmt.Errorf("request is nil"))
+		return errorutil.Internal("request is nil")
 	}
 
 	if permissions.IsProjectScope(req) {
@@ -50,7 +50,7 @@ func (a *authorizer) Authorize(ctx context.Context, token *apiv2.Token, req conn
 		if ok {
 			subject = project
 		} else {
-			return connect.NewError(connect.CodeInvalidArgument, errors.New("no project found in project scoped request"))
+			return errorutil.InvalidArgument("no project found in project scoped request")
 		}
 	}
 
@@ -59,7 +59,7 @@ func (a *authorizer) Authorize(ctx context.Context, token *apiv2.Token, req conn
 		if ok {
 			subject = tenant
 		} else {
-			return connect.NewError(connect.CodeInvalidArgument, errors.New("no tenant found in tenant scoped request"))
+			return errorutil.InvalidArgument("no tenant found in tenant scoped request")
 		}
 	}
 
@@ -68,7 +68,7 @@ func (a *authorizer) Authorize(ctx context.Context, token *apiv2.Token, req conn
 		if ok {
 			subject = machineId
 		} else {
-			return connect.NewError(connect.CodeInvalidArgument, errors.New("no machine uuid found in machine scoped request"))
+			return errorutil.InvalidArgument("no machine uuid found in machine scoped request")
 		}
 	}
 
@@ -78,19 +78,23 @@ func (a *authorizer) Authorize(ctx context.Context, token *apiv2.Token, req conn
 func (a *authorizer) authorize(ctx context.Context, token *apiv2.Token, method string, subject string) error {
 	a.log.Debug("authorize", "token", token, "method", method, "subject", subject)
 
+	if _, ok := permissions.GetServicePermissions().Methods[method]; !ok {
+		return errorutil.PermissionDenied("requested procedure %q is not known", method)
+	}
+
 	permissions, err := a.getTokenPermissions(ctx, token)
 	if err != nil {
-		return connect.NewError(connect.CodeInternal, err)
+		return errorutil.NewInternal(err)
 	}
 	if permissions == nil {
-		return connect.NewError(connect.CodePermissionDenied, errors.New("no permissions found in token"))
+		return errorutil.PermissionDenied("no permissions found in token")
 	}
 
 	a.log.Debug("authorize", "permissions", permissions, "method", method, "subject", subject)
 
 	subjects, ok := permissions[method]
 	if !ok {
-		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("access to:%q is not allowed because it is not part of the token permissions", method))
+		return errorutil.PermissionDenied("access to:%q is not allowed because it is not part of the token permissions", method)
 	}
 
 	if _, allSubjectsAllowed := subjects[AnySubject]; allSubjectsAllowed {
@@ -103,7 +107,8 @@ func (a *authorizer) authorize(ctx context.Context, token *apiv2.Token, method s
 		for s := range subjects {
 			allowedSubjects = append(allowedSubjects, s)
 		}
-		return connect.NewError(connect.CodePermissionDenied, fmt.Errorf("access to:%q with subject:%q is not allowed because it is not part of the token permissions, allowed subjects are:%q", method, subject, allowedSubjects))
+		slices.Sort(allowedSubjects)
+		return errorutil.PermissionDenied("access to:%q with subject:%q is not allowed because it is not part of the token permissions, allowed subjects are:%q", method, subject, allowedSubjects)
 	}
 
 	return nil

--- a/pkg/request/authorize_test.go
+++ b/pkg/request/authorize_test.go
@@ -299,6 +299,370 @@ func Test_authorizer_allowed(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "api token, multiple permissions with different subjects allowed",
+			token: &apiv2.Token{
+				User:      "user-c",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				Permissions: []*apiv2.MethodPermission{
+					{Subject: "project-a", Methods: []string{"/metalstack.api.v2.IPService/Get"}},
+					{Subject: "project-b", Methods: []string{"/metalstack.api.v2.IPService/Get"}},
+				},
+			},
+			method:  apiv2connect.IPServiceGetProcedure,
+			subject: "project-a",
+			projectsAndTenants: &api.ProjectsAndTenants{
+				ProjectRoles: map[string]apiv2.ProjectRole{
+					"project-a": apiv2.ProjectRole_PROJECT_ROLE_VIEWER,
+					"project-b": apiv2.ProjectRole_PROJECT_ROLE_VIEWER,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "api token, multiple permissions with different subjects denied",
+			token: &apiv2.Token{
+				User:      "user-c",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				Permissions: []*apiv2.MethodPermission{
+					{Subject: "project-a", Methods: []string{"/metalstack.api.v2.IPService/Get"}},
+					{Subject: "project-b", Methods: []string{"/metalstack.api.v2.IPService/Get"}},
+				},
+			},
+			method:  apiv2connect.IPServiceGetProcedure,
+			subject: "project-c",
+			projectsAndTenants: &api.ProjectsAndTenants{
+				ProjectRoles: map[string]apiv2.ProjectRole{
+					"project-a": apiv2.ProjectRole_PROJECT_ROLE_VIEWER,
+					"project-b": apiv2.ProjectRole_PROJECT_ROLE_VIEWER,
+				},
+			},
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.api.v2.IPService/Get\" with subject:\"project-c\" is not allowed because it is not part of the token permissions, allowed subjects are:[\"project-a\" \"project-b\"]"),
+		},
+		{
+			name: "api token, empty permissions list denied",
+			token: &apiv2.Token{
+				User:        "user-d",
+				TokenType:   apiv2.TokenType_TOKEN_TYPE_API,
+				Permissions: []*apiv2.MethodPermission{},
+			},
+			method:  apiv2connect.IPServiceGetProcedure,
+			subject: "project-a",
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.api.v2.IPService/Get\" is not allowed because it is not part of the token permissions"),
+		},
+		{
+			name: "user token without tenant roles on non-public method denied",
+			token: &apiv2.Token{
+				User:      "user-e",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_USER,
+			},
+			method:  apiv2connect.IPServiceGetProcedure,
+			subject: "project-a",
+			projectsAndTenants: &api.ProjectsAndTenants{
+				ProjectRoles: map[string]apiv2.ProjectRole{},
+			},
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.api.v2.IPService/Get\" is not allowed because it is not part of the token permissions"),
+		},
+		{
+			name: "admin editor all methods allowed regardless of permission",
+			token: &apiv2.Token{
+				User:      "admin-x",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				AdminRole: apiv2.AdminRole_ADMIN_ROLE_EDITOR.Enum(),
+			},
+			method:  apiv2connect.MachineServiceCreateProcedure,
+			subject: "project-f",
+			wantErr: nil,
+		},
+		{
+			name: "admin viewer on viewer method allowed",
+			token: &apiv2.Token{
+				User:      "admin-v",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				AdminRole: apiv2.AdminRole_ADMIN_ROLE_VIEWER.Enum(),
+			},
+			method:  apiv2connect.IPServiceGetProcedure,
+			subject: "project-g",
+			wantErr: nil,
+		},
+		{
+			name: "infra viewer on infra viewer method allowed",
+			token: &apiv2.Token{
+				User:      "metal-core",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				InfraRole: apiv2.InfraRole_INFRA_ROLE_VIEWER.Enum(),
+			},
+			method:  infrav2connect.SwitchServiceGetProcedure,
+			subject: "",
+			wantErr: nil,
+		},
+		{
+			name: "api token with wildcard subject and specific method allowed",
+			token: &apiv2.Token{
+				User:      "user-wildcard",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				Permissions: []*apiv2.MethodPermission{
+					{Subject: "*", Methods: []string{"/metalstack.api.v2.IPService/Get"}},
+				},
+			},
+			method:  apiv2connect.IPServiceGetProcedure,
+			subject: "project-h",
+			projectsAndTenants: &api.ProjectsAndTenants{
+				Projects: []*apiv2.Project{
+					{Uuid: "project-h"},
+				},
+				ProjectRoles: map[string]apiv2.ProjectRole{
+					"project-h": apiv2.ProjectRole_PROJECT_ROLE_VIEWER,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "api token wildcard project subject but project not in user scope denied",
+			token: &apiv2.Token{
+				User:      "user-scoped",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				Permissions: []*apiv2.MethodPermission{
+					{Subject: "*", Methods: []string{"/metalstack.api.v2.IPService/Get"}},
+				},
+			},
+			method:  apiv2connect.IPServiceGetProcedure,
+			subject: "project-unauthorized",
+			projectsAndTenants: &api.ProjectsAndTenants{
+				ProjectRoles: map[string]apiv2.ProjectRole{
+					"project-h": apiv2.ProjectRole_PROJECT_ROLE_VIEWER,
+				},
+			},
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.api.v2.IPService/Get\" with subject:\"project-unauthorized\" is not allowed because it is not part of the token permissions, allowed subjects are:[\"project-h\"]"),
+		},
+		{
+			name: "api token combined tenant and project scope with * permissions",
+			token: &apiv2.Token{
+				User:      "user-multi",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				Permissions: []*apiv2.MethodPermission{
+					{Subject: "*", Methods: []string{"/metalstack.api.v2.ProjectService/Create"}},
+					{Subject: "*", Methods: []string{"/metalstack.api.v2.MachineService/Create"}},
+				},
+			},
+			method:  apiv2connect.ProjectServiceCreateProcedure,
+			subject: "tenant-multi",
+			projectsAndTenants: &api.ProjectsAndTenants{
+				Projects: []*apiv2.Project{
+					{Uuid: "project-multi"},
+				},
+				Tenants: []*apiv2.Tenant{
+					{Login: "tenant-multi"},
+				},
+				TenantRoles: map[string]apiv2.TenantRole{
+					"tenant-multi": apiv2.TenantRole_TENANT_ROLE_OWNER,
+				},
+				ProjectRoles: map[string]apiv2.ProjectRole{
+					"project-multi": apiv2.ProjectRole_PROJECT_ROLE_EDITOR,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "nil token on public version method allowed",
+			token:   nil,
+			method:  apiv2connect.VersionServiceGetProcedure,
+			wantErr: nil,
+		},
+		{
+			name: "empty string subject with wildcard permission allowed",
+			token: &apiv2.Token{
+				User:      "user-empty",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				Permissions: []*apiv2.MethodPermission{
+					{Subject: "*", Methods: []string{infrav2connect.SwitchServiceRegisterProcedure}},
+				},
+			},
+			method:  infrav2connect.SwitchServiceRegisterProcedure,
+			subject: "",
+			wantErr: nil,
+		},
+		{
+			name: "api token with wildcard permission to non-project method no subject",
+			token: &apiv2.Token{
+				User:      "user-nonproj",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				Permissions: []*apiv2.MethodPermission{
+					{Subject: "*", Methods: []string{"/metalstack.api.v2.SelfService/Me"}},
+				},
+			},
+			method:  "/metalstack.api.v2.SelfService/Me",
+			subject: "",
+			wantErr: errorutil.PermissionDenied(`requested procedure "/metalstack.api.v2.SelfService/Me" is not known`),
+		},
+		{
+			name: "user token with tenant viewer role on tenant scoped method",
+			token: &apiv2.Token{
+				User:      "user-tenant",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_USER,
+				TenantRoles: map[string]apiv2.TenantRole{
+					"tenant-viewer": apiv2.TenantRole_TENANT_ROLE_VIEWER,
+				},
+			},
+			method:  apiv2connect.ProjectServiceListProcedure,
+			subject: "tenant-viewer",
+			projectsAndTenants: &api.ProjectsAndTenants{
+				TenantRoles: map[string]apiv2.TenantRole{
+					"tenant-viewer": apiv2.TenantRole_TENANT_ROLE_VIEWER,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "api token with machine editor role allowed on boot service",
+			token: &apiv2.Token{
+				User:         "user-machine",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"machine-02": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  "/metalstack.infra.v2.BootService/SuperUserPassword",
+			subject: "machine-02",
+			wantErr: nil,
+		},
+		{
+			name: "api token with machine editor role denied on non-boot method",
+			token: &apiv2.Token{
+				User:         "user-machine",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"machine-02": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  apiv2connect.MachineServiceDeleteProcedure,
+			subject: "machine-02",
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.api.v2.MachineService/Delete\" is not allowed because it is not part of the token permissions"),
+		},
+		{
+			name: "api token user with project viewer role allowed",
+			token: &apiv2.Token{
+				User:      "user-proj",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_USER,
+				ProjectRoles: map[string]apiv2.ProjectRole{
+					"proj-viewer": apiv2.ProjectRole_PROJECT_ROLE_VIEWER,
+				},
+			},
+			method:  apiv2connect.IPServiceGetProcedure,
+			subject: "proj-viewer",
+			projectsAndTenants: &api.ProjectsAndTenants{
+				ProjectRoles: map[string]apiv2.ProjectRole{
+					"proj-viewer": apiv2.ProjectRole_PROJECT_ROLE_VIEWER,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "admin viewer not allowed on editor-only method",
+			token: &apiv2.Token{
+				User:      "admin-wrong",
+				TokenType: apiv2.TokenType_TOKEN_TYPE_API,
+				AdminRole: apiv2.AdminRole_ADMIN_ROLE_VIEWER.Enum(),
+			},
+			method:  apiv2connect.MachineServiceCreateProcedure,
+			subject: "project-x",
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.api.v2.MachineService/Create\" is not allowed because it is not part of the token permissions"),
+		},
+		{
+			name: "api token with machine editor role allowed on BootServiceRegister with correct UUID",
+			token: &apiv2.Token{
+				User:         "machine-prov",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"abc-def-123": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  infrav2connect.BootServiceRegisterProcedure,
+			subject: "abc-def-123",
+			wantErr: nil,
+		},
+		{
+			name: "api token with machine editor role denied on BootServiceRegister with wrong UUID",
+			token: &apiv2.Token{
+				User:         "machine-prov",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"abc-def-123": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  infrav2connect.BootServiceRegisterProcedure,
+			subject: "wrong-uuid-456",
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.infra.v2.BootService/Register\" with subject:\"wrong-uuid-456\" is not allowed because it is not part of the token permissions, allowed subjects are:[\"abc-def-123\"]"),
+		},
+		{
+			name: "api token with machine editor role denied on wrong method for a machine",
+			token: &apiv2.Token{
+				User:         "machine-prov",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"abc-def-123": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  apiv2connect.MachineServiceDeleteProcedure,
+			subject: "abc-def-123",
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.api.v2.MachineService/Delete\" is not allowed because it is not part of the token permissions"),
+		},
+		{
+			name: "api token with machine editor role denied on non-machine method regardless of UUID",
+			token: &apiv2.Token{
+				User:         "machine-prov",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"abc-def-123": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  infrav2connect.SwitchServiceRegisterProcedure,
+			subject: "abc-def-123",
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.infra.v2.SwitchService/Register\" is not allowed because it is not part of the token permissions"),
+		},
+		{
+			name: "api token with machine editor role allowed on BootServiceWait with correct UUID",
+			token: &apiv2.Token{
+				User:         "machine-prov2",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"xyz-789": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  infrav2connect.BootServiceWaitProcedure,
+			subject: "xyz-789",
+			wantErr: nil,
+		},
+		{
+			name: "api token with machine editor role denied on non-editor machine method",
+			token: &apiv2.Token{
+				User:         "machine-prov2",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"xyz-789": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  infrav2connect.SwitchServiceRegisterProcedure,
+			subject: "machine-uuid-different",
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.infra.v2.SwitchService/Register\" is not allowed because it is not part of the token permissions"),
+		},
+		{
+			name: "multiple machine roles, access allowed for one UUID",
+			token: &apiv2.Token{
+				User:         "multi-machine",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"machine-a": apiv2.MachineRole_MACHINE_ROLE_EDITOR, "machine-b": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  infrav2connect.BootServiceRegisterProcedure,
+			subject: "machine-b",
+			wantErr: nil,
+		},
+		{
+			name: "wildcard machine role, access allowed for arbitrary uuid",
+			token: &apiv2.Token{
+				User:         "multi-machine",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"*": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  infrav2connect.BootServiceRegisterProcedure,
+			subject: "machine-b",
+			wantErr: nil,
+		},
+		{
+			name: "multiple machine roles, access denied for unknown UUID",
+			token: &apiv2.Token{
+				User:         "multi-machine",
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				MachineRoles: map[string]apiv2.MachineRole{"machine-a": apiv2.MachineRole_MACHINE_ROLE_EDITOR, "machine-b": apiv2.MachineRole_MACHINE_ROLE_EDITOR},
+			},
+			method:  infrav2connect.BootServiceRegisterProcedure,
+			subject: "machine-c",
+			wantErr: errorutil.PermissionDenied("access to:\"/metalstack.infra.v2.BootService/Register\" with subject:\"machine-c\" is not allowed because it is not part of the token permissions, allowed subjects are:[\"machine-a\" \"machine-b\"]"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/service/admin/audit/audit-service.go
+++ b/pkg/service/admin/audit/audit-service.go
@@ -2,11 +2,9 @@ package adminaudit
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
 
-	"connectrpc.com/connect"
+	"github.com/metal-stack/api/go/errorutil"
 	adminv2 "github.com/metal-stack/api/go/metalstack/admin/v2"
 	"github.com/metal-stack/api/go/metalstack/admin/v2/adminv2connect"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
@@ -36,7 +34,7 @@ func New(c Config) adminv2connect.AuditServiceHandler {
 
 func (a *auditServiceServer) Get(ctx context.Context, rq *adminv2.AuditServiceGetRequest) (*adminv2.AuditServiceGetResponse, error) {
 	if a.disabled {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("the audit backend is currently disabled"))
+		return nil, errorutil.FailedPrecondition("the audit backend is currently disabled")
 	}
 
 	phase := apiv2.AuditPhase_AUDIT_PHASE_REQUEST
@@ -54,17 +52,17 @@ func (a *auditServiceServer) Get(ctx context.Context, rq *adminv2.AuditServiceGe
 
 	switch len(traces) {
 	case 0:
-		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("no audit trace found for given request id %q", rq.Uuid))
+		return nil, errorutil.NotFound("no audit trace found for given request id %q", rq.Uuid)
 	case 1:
 		return &adminv2.AuditServiceGetResponse{Trace: traces[0]}, nil
 	default:
-		return nil, connect.NewError(connect.CodeInternal, errors.New("unable to find distinct audit entry, search result is ambiguous"))
+		return nil, errorutil.Internal("unable to find distinct audit entry, search result is ambiguous")
 	}
 }
 
 func (a *auditServiceServer) List(ctx context.Context, rq *adminv2.AuditServiceListRequest) (*adminv2.AuditServiceListResponse, error) {
 	if a.disabled {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("the audit backend is currently disabled"))
+		return nil, errorutil.FailedPrecondition("the audit backend is currently disabled")
 	}
 
 	traces, err := a.repo.List(ctx, rq.Query)

--- a/pkg/service/admin/vpn/vpn-service.go
+++ b/pkg/service/admin/vpn/vpn-service.go
@@ -2,10 +2,9 @@ package admin
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
-	"connectrpc.com/connect"
+	"github.com/metal-stack/api/go/errorutil"
 	adminv2 "github.com/metal-stack/api/go/metalstack/admin/v2"
 	"github.com/metal-stack/api/go/metalstack/admin/v2/adminv2connect"
 	"github.com/metal-stack/metal-apiserver/pkg/repository"
@@ -30,7 +29,7 @@ func New(c Config) adminv2connect.VPNServiceHandler {
 
 func (v *vpnService) AuthKey(ctx context.Context, req *adminv2.VPNServiceAuthKeyRequest) (*adminv2.VPNServiceAuthKeyResponse, error) {
 	if !v.repo.UnscopedVPN().Enabled() {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("vpn is currently disabled"))
+		return nil, errorutil.FailedPrecondition("vpn is currently disabled")
 	}
 
 	key, err := v.repo.VPN(req.Project).CreateAuthKey(ctx, req)
@@ -43,7 +42,7 @@ func (v *vpnService) AuthKey(ctx context.Context, req *adminv2.VPNServiceAuthKey
 
 func (v *vpnService) ListNodes(ctx context.Context, req *adminv2.VPNServiceListNodesRequest) (*adminv2.VPNServiceListNodesResponse, error) {
 	if !v.repo.UnscopedVPN().Enabled() {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("vpn is currently disabled"))
+		return nil, errorutil.FailedPrecondition("vpn is currently disabled")
 	}
 
 	nodes, err := v.repo.UnscopedVPN().ListNodes(ctx, req)

--- a/pkg/service/api/audit/audit-service.go
+++ b/pkg/service/api/audit/audit-service.go
@@ -2,11 +2,9 @@ package audit
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
 
-	"connectrpc.com/connect"
+	"github.com/metal-stack/api/go/errorutil"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
 	"github.com/metal-stack/api/go/metalstack/api/v2/apiv2connect"
 	"github.com/metal-stack/metal-apiserver/pkg/repository"
@@ -37,7 +35,7 @@ func New(c Config) apiv2connect.AuditServiceHandler {
 
 func (a *auditServiceServer) Get(ctx context.Context, rq *apiv2.AuditServiceGetRequest) (*apiv2.AuditServiceGetResponse, error) {
 	if a.disabled {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("the audit backend is currently disabled"))
+		return nil, errorutil.FailedPrecondition("the audit backend is currently disabled")
 	}
 
 	phase := apiv2.AuditPhase_AUDIT_PHASE_REQUEST
@@ -55,17 +53,17 @@ func (a *auditServiceServer) Get(ctx context.Context, rq *apiv2.AuditServiceGetR
 
 	switch len(traces) {
 	case 0:
-		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("no audit trace found for given request id %q", rq.Uuid))
+		return nil, errorutil.NotFound("no audit trace found for given request id %q", rq.Uuid)
 	case 1:
 		return &apiv2.AuditServiceGetResponse{Trace: traces[0]}, nil
 	default:
-		return nil, connect.NewError(connect.CodeInternal, errors.New("unable to find distinct audit entry, search result is ambiguous"))
+		return nil, errorutil.Internal("unable to find distinct audit entry, search result is ambiguous")
 	}
 }
 
 func (a *auditServiceServer) List(ctx context.Context, rq *apiv2.AuditServiceListRequest) (*apiv2.AuditServiceListResponse, error) {
 	if a.disabled {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("the audit backend is currently disabled"))
+		return nil, errorutil.FailedPrecondition("the audit backend is currently disabled")
 	}
 
 	traces, err := a.repo.Audit(rq.Login).List(ctx, rq.Query)


### PR DESCRIPTION
## Description

Let the ai generate more authorize permutations, including machine scoped requests.
Also refactored some old connect errors with errorutil

Closes #255 

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- Qwen3.6 used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
