### PR TITLE
RFC: Cache often used, but rarely updated entities

### DIFF
--- a/pkg/db/generic/datastore.go
+++ b/pkg/db/generic/datastore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/metal-stack/metal-apiserver/pkg/db/metal"
 	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
@@ -57,15 +58,18 @@ func New(log *slog.Logger, opts r.ConnectOpts, dsOpts ...dataStoreOption) (*data
 		dbname:        opts.Database,
 	}
 
+	// Cache entities which are rarely modified
+	cacheExpiration := new(60 * time.Minute)
+
 	ds.ip = newStorage[*metal.IP](ds, "ip")
 	ds.machine = newStorage[*metal.Machine](ds, "machine")
-	ds.size = newStorage[*metal.Size](ds, "size")
+	ds.size = newCachedStorage[*metal.Size](ds, "size", cacheExpiration)
 	ds.sizeImageConstraint = newStorage[*metal.SizeImageConstraint](ds, "sizeimageconstraint")
 	ds.sizeReservation = newStorage[*metal.SizeReservation](ds, "sizereservation")
-	ds.partition = newStorage[*metal.Partition](ds, "partition")
+	ds.partition = newCachedStorage[*metal.Partition](ds, "partition", cacheExpiration)
 	ds.network = newStorage[*metal.Network](ds, "network")
-	ds.fsl = newStorage[*metal.FilesystemLayout](ds, "filesystemlayout")
-	ds.image = newStorage[*metal.Image](ds, "image")
+	ds.fsl = newCachedStorage[*metal.FilesystemLayout](ds, "filesystemlayout", cacheExpiration)
+	ds.image = newCachedStorage[*metal.Image](ds, "image", cacheExpiration)
 	ds.event = newStorage[*metal.ProvisioningEventContainer](ds, "event")
 	ds.sw = newStorage[*metal.Switch](ds, "switch")
 	ds.switchStatus = newStorage[*metal.SwitchStatus](ds, "switchstatus")

--- a/pkg/db/generic/storage.go
+++ b/pkg/db/generic/storage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/metal-stack/api/go/errorutil"
+	"github.com/metal-stack/metal-lib/pkg/cache"
 	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
 )
 
@@ -16,16 +17,55 @@ type storage[E Entity] struct {
 	r         *datastore
 	table     r.Term
 	tableName string
+	cache     *cache.Cache[string, E]
 }
 
 // newStorage creates a new Storage which uses the given database abstraction.
 func newStorage[E Entity](re *datastore, tableName string) *storage[E] {
 	re.tableNames = append(re.tableNames, tableName)
+
 	return &storage[E]{
 		r:         re,
 		table:     r.DB(re.dbname).Table(tableName),
 		tableName: tableName,
 	}
+}
+
+// newStorage creates a new Storage which uses the given database abstraction.
+func newCachedStorage[E Entity](re *datastore, tableName string, withCacheExpiration *time.Duration) *storage[E] {
+	s := newStorage[E](re, tableName)
+
+	var c *cache.Cache[string, E]
+	if withCacheExpiration != nil {
+		c = cache.New(*withCacheExpiration, func(ctx context.Context, id string) (E, error) {
+			var zero E
+			res, err := s.table.Get(id).Run(s.r.queryExecutor, r.RunOpts{Context: ctx})
+			if err != nil {
+				return zero, fmt.Errorf("cannot find %v with id %q in database: %w", s.tableName, id, err)
+			}
+
+			defer func() {
+				if err := res.Close(); err != nil {
+					s.r.log.Error("unable to close database connection", "error", err)
+				}
+			}()
+			if res.IsNil() {
+				return zero, errorutil.NotFound("no %v with id %q found", s.tableName, id)
+			}
+
+			e := new(E)
+			err = res.One(e)
+			if err != nil {
+				return zero, fmt.Errorf("more than one %v with same id exists: %w", s.tableName, err)
+			}
+
+			return *e, nil
+		})
+
+		s.cache = c
+	}
+
+	return s
 }
 
 // Create creates the given entity in the database. in case it is already present, a conflict error will be returned.
@@ -152,6 +192,9 @@ func (s *storage[E]) List(ctx context.Context, queries ...EntityQuery) ([]E, err
 
 // Get returns the entity of the given ID  from the database.
 func (s *storage[E]) Get(ctx context.Context, id string) (E, error) {
+	if s.cache != nil {
+		return s.cache.Get(ctx, id)
+	}
 	var zero E
 	res, err := s.table.Get(id).Run(s.r.queryExecutor, r.RunOpts{Context: ctx})
 	if err != nil {


### PR DESCRIPTION
## Description

Size, Partition, FilesystemLayout and Image are often read (for e.g. in machine get/list) but very seldom modified. 
Caching these Entities should speed up machine get/list quite a bit.

Fails actually because error messages differ now on not found:

```
partition-service_test.go:503: diff =   (*connect.Error)(
    - 	e`not_found: error fetching cache entry: no partition with id "partition-5" found`,
    + 	e`not_found: no partition with id "partition-5" found`,
```


#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
