### PR TITLE
Fix image-cache-sync token refresh permission issue

### DIFF
--- a/pkg/e2e/apiserver.go
+++ b/pkg/e2e/apiserver.go
@@ -62,6 +62,7 @@ func StartApiserver(t testing.TB, log *slog.Logger, additionalTenants ...string)
 		MaxRequestsPerMinuteToken:           100,
 		MaxRequestsPerMinuteUnauthenticated: 100,
 		HeadscaleClient:                     hc,
+		ComponentExpiration:                 time.Hour,
 	}
 
 	mux, err := service.New(ctx, log, c)

--- a/pkg/e2e/apiserver_test.go
+++ b/pkg/e2e/apiserver_test.go
@@ -9,11 +9,8 @@ import (
 	"github.com/metal-stack/api/go/client"
 	adminv2 "github.com/metal-stack/api/go/metalstack/admin/v2"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
-	infrav2 "github.com/metal-stack/api/go/metalstack/infra/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestUnauthenticated(t *testing.T) {
@@ -111,72 +108,6 @@ func TestListBaseNetworks(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, nslr)
 	require.Len(t, nslr.Networks, 1)
-}
-
-func TestImageCacheServiceToken(t *testing.T) {
-	t.Parallel()
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	baseURL, adminToken, tenantTokenSecrets, closer := StartApiserver(t, log, "metal-image-cache-sync")
-	defer closer()
-	require.NotNil(t, baseURL, adminToken)
-	log.Info("token", "secret", tenantTokenSecrets["metal-image-cache-sync"])
-
-	adminClient, err := client.New(&client.DialConfig{
-		BaseURL:   baseURL,
-		Token:     adminToken,
-		UserAgent: "integration test admin",
-		Log:       log,
-	})
-	require.NoError(t, err)
-
-	tokenResp, err := adminClient.Adminv2().Token().Create(t.Context(), &adminv2.TokenServiceCreateRequest{
-		User: new("metal-image-cache-sync"),
-		TokenCreateRequest: &apiv2.TokenServiceCreateRequest{
-			Description: "metal-image-cache-sync token",
-			Permissions: []*apiv2.MethodPermission{
-				{
-					Subject: "*",
-					Methods: []string{
-						"/metalstack.api.v2.ImageService/List",
-					},
-				},
-				{
-					Subject: "",
-					Methods: []string{
-						"/metalstack.api.v2.PartitionService/List",
-						"/metalstack.api.v2.TokenService/Refresh",
-						"/metalstack.infra.v2.ComponentService/Ping",
-					},
-				},
-			},
-			Expires: durationpb.New(10 * time.Minute),
-		},
-	})
-	require.NoError(t, err)
-
-	userClient, err := client.New(&client.DialConfig{
-		BaseURL:   baseURL,
-		Token:     tokenResp.Secret,
-		UserAgent: "metal-image-cache-sync user",
-		Log:       log,
-	})
-	require.NoError(t, err)
-	_, err = userClient.Infrav2().Component().Ping(t.Context(), &infrav2.ComponentServicePingRequest{
-		Type:       apiv2.ComponentType_COMPONENT_TYPE_METAL_IMAGE_CACHE_SYNC,
-		Identifier: "image-cache-e2e",
-		StartedAt:  timestamppb.Now(),
-		Interval:   durationpb.New(5 * time.Minute),
-		Version:    &apiv2.Version{Version: "v0.0.0", Revision: "abc"},
-	})
-	require.NoError(t, err)
-
-	_, err = userClient.Apiv2().Image().List(t.Context(), &apiv2.ImageServiceListRequest{})
-	require.NoError(t, err)
-
-	_, err = userClient.Apiv2().Partition().List(t.Context(), &apiv2.PartitionServiceListRequest{})
-	require.NoError(t, err)
-	_, err = userClient.Apiv2().Token().Refresh(t.Context(), &apiv2.TokenServiceRefreshRequest{})
-	require.NoError(t, err)
 }
 
 func TestHealthGet(t *testing.T) {

--- a/pkg/e2e/apiserver_test.go
+++ b/pkg/e2e/apiserver_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/metal-stack/api/go/client"
 	adminv2 "github.com/metal-stack/api/go/metalstack/admin/v2"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
+	infrav2 "github.com/metal-stack/api/go/metalstack/infra/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestUnauthenticated(t *testing.T) {
@@ -133,11 +135,17 @@ func TestImageCacheServiceToken(t *testing.T) {
 			Description: "metal-image-cache-sync token",
 			Permissions: []*apiv2.MethodPermission{
 				{
-					Subject: "",
+					Subject: "*",
 					Methods: []string{
 						"/metalstack.api.v2.ImageService/List",
+					},
+				},
+				{
+					Subject: "",
+					Methods: []string{
 						"/metalstack.api.v2.PartitionService/List",
 						"/metalstack.api.v2.TokenService/Refresh",
+						"/metalstack.infra.v2.ComponentService/Ping",
 					},
 				},
 			},
@@ -153,11 +161,21 @@ func TestImageCacheServiceToken(t *testing.T) {
 		Log:       log,
 	})
 	require.NoError(t, err)
+	_, err = userClient.Infrav2().Component().Ping(t.Context(), &infrav2.ComponentServicePingRequest{
+		Type:       apiv2.ComponentType_COMPONENT_TYPE_METAL_IMAGE_CACHE_SYNC,
+		Identifier: "image-cache-e2e",
+		StartedAt:  timestamppb.Now(),
+		Interval:   durationpb.New(5 * time.Minute),
+		Version:    &apiv2.Version{Version: "v0.0.0", Revision: "abc"},
+	})
+	require.NoError(t, err)
 
 	_, err = userClient.Apiv2().Image().List(t.Context(), &apiv2.ImageServiceListRequest{})
 	require.NoError(t, err)
 
 	_, err = userClient.Apiv2().Partition().List(t.Context(), &apiv2.PartitionServiceListRequest{})
+	require.NoError(t, err)
+	_, err = userClient.Apiv2().Token().Refresh(t.Context(), &apiv2.TokenServiceRefreshRequest{})
 	require.NoError(t, err)
 }
 

--- a/pkg/e2e/image-cache_test.go
+++ b/pkg/e2e/image-cache_test.go
@@ -37,14 +37,9 @@ func TestImageCacheServiceToken(t *testing.T) {
 			Description: "metal-image-cache-sync token",
 			Permissions: []*apiv2.MethodPermission{
 				{
-					Subject: "*",
-					Methods: []string{
-						"/metalstack.api.v2.ImageService/List",
-					},
-				},
-				{
 					Subject: "",
 					Methods: []string{
+						"/metalstack.api.v2.ImageService/List",
 						"/metalstack.api.v2.PartitionService/List",
 						"/metalstack.api.v2.TokenService/Refresh",
 						"/metalstack.infra.v2.ComponentService/Ping",

--- a/pkg/e2e/image-cache_test.go
+++ b/pkg/e2e/image-cache_test.go
@@ -1,0 +1,83 @@
+package e2e
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/metal-stack/api/go/client"
+	adminv2 "github.com/metal-stack/api/go/metalstack/admin/v2"
+	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
+	infrav2 "github.com/metal-stack/api/go/metalstack/infra/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestImageCacheServiceToken(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	baseURL, adminToken, tenantTokenSecrets, closer := StartApiserver(t, log, "metal-image-cache-sync")
+	defer closer()
+	require.NotNil(t, baseURL, adminToken)
+	log.Info("token", "secret", tenantTokenSecrets["metal-image-cache-sync"])
+
+	adminClient, err := client.New(&client.DialConfig{
+		BaseURL:   baseURL,
+		Token:     adminToken,
+		UserAgent: "integration test admin",
+		Log:       log,
+	})
+	require.NoError(t, err)
+
+	tcr := &adminv2.TokenServiceCreateRequest{
+		User: new("metal-image-cache-sync"),
+		TokenCreateRequest: &apiv2.TokenServiceCreateRequest{
+			Description: "metal-image-cache-sync token",
+			Permissions: []*apiv2.MethodPermission{
+				{
+					Subject: "*",
+					Methods: []string{
+						"/metalstack.api.v2.ImageService/List",
+					},
+				},
+				{
+					Subject: "",
+					Methods: []string{
+						"/metalstack.api.v2.PartitionService/List",
+						"/metalstack.api.v2.TokenService/Refresh",
+						"/metalstack.infra.v2.ComponentService/Ping",
+					},
+				},
+			},
+			Expires: durationpb.New(10 * time.Minute),
+		},
+	}
+	tokenResp, err := adminClient.Adminv2().Token().Create(t.Context(), tcr)
+	require.NoError(t, err)
+
+	userClient, err := client.New(&client.DialConfig{
+		BaseURL:   baseURL,
+		Token:     tokenResp.Secret,
+		UserAgent: "metal-image-cache-sync user",
+		Log:       log,
+	})
+	require.NoError(t, err)
+	_, err = userClient.Infrav2().Component().Ping(t.Context(), &infrav2.ComponentServicePingRequest{
+		Type:       apiv2.ComponentType_COMPONENT_TYPE_METAL_IMAGE_CACHE_SYNC,
+		Identifier: "image-cache-e2e",
+		StartedAt:  timestamppb.Now(),
+		Interval:   durationpb.New(5 * time.Minute),
+		Version:    &apiv2.Version{Version: "v0.0.0", Revision: "abc"},
+	})
+	require.NoError(t, err)
+
+	_, err = userClient.Apiv2().Image().List(t.Context(), &apiv2.ImageServiceListRequest{})
+	require.NoError(t, err)
+
+	_, err = userClient.Apiv2().Partition().List(t.Context(), &apiv2.PartitionServiceListRequest{})
+	require.NoError(t, err)
+	_, err = userClient.Apiv2().Token().Refresh(t.Context(), &apiv2.TokenServiceRefreshRequest{})
+	require.NoError(t, err)
+}

--- a/pkg/repository/component.go
+++ b/pkg/repository/component.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"time"
 
@@ -81,17 +82,17 @@ func (c *componentRepository) validateCreate(ctx context.Context, rq *api.Compon
 func (c *componentRepository) create(ctx context.Context, rq *api.ComponentServiceCreateRequest) (*componentEntity, error) {
 	payload, err := json.Marshal(rq)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to marshal component create request: %w", err)
 	}
 
 	key, err := c.key(rq.Component)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get component key: %w", err)
 	}
 
 	err = c.s.component.Do(ctx, c.s.component.B().Set().Key(key).Value(string(payload)).Ex(rq.Expiration).Build()).Error()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to store component: %w", err)
 	}
 	return &componentEntity{Component: rq.Component}, err
 }

--- a/pkg/repository/token.go
+++ b/pkg/repository/token.go
@@ -374,6 +374,7 @@ func (t *tokenRepository) Refresh(ctx context.Context, uuid string) (*apiv2.Toke
 	}
 	fullUserToken := &apiv2.Token{
 		User:         t.scope.user,
+		Permissions:  tok.Permissions,
 		ProjectRoles: projectsAndTenants.ProjectRoles,
 		TenantRoles:  projectsAndTenants.TenantRoles,
 		AdminRole:    nil,
@@ -423,6 +424,8 @@ func (t *tokenRepository) Refresh(ctx context.Context, uuid string) (*apiv2.Toke
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO, should we delete the old token now ?
 
 	return &apiv2.TokenServiceRefreshResponse{
 		Token:  newToken,

--- a/pkg/service/api/token/token-service_test.go
+++ b/pkg/service/api/token/token-service_test.go
@@ -2255,6 +2255,70 @@ func Test_Refresh(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "refresh preserves method permissions from existing token",
+			sessionToken: &apiv2.Token{
+				User: "phippy",
+				Uuid: token1,
+				Permissions: []*apiv2.MethodPermission{
+					{
+						Subject: "",
+						Methods: []string{
+							"/metalstack.api.v2.PartitionService/List",
+							"/metalstack.api.v2.TokenService/Refresh",
+							"/metalstack.infra.v2.ComponentService/Ping",
+						},
+					},
+				},
+				ProjectRoles: map[string]apiv2.ProjectRole{},
+				TenantRoles:  map[string]apiv2.TenantRole{},
+				MachineRoles: map[string]apiv2.MachineRole{},
+			},
+			existingToken: &apiv2.Token{
+				Uuid: token1,
+				User: "phippy",
+				Permissions: []*apiv2.MethodPermission{{
+					Subject: "",
+					Methods: []string{
+						"/metalstack.api.v2.PartitionService/List",
+						"/metalstack.api.v2.TokenService/Refresh",
+						"/metalstack.infra.v2.ComponentService/Ping",
+					},
+				}},
+				ProjectRoles: map[string]apiv2.ProjectRole{},
+				TenantRoles:  map[string]apiv2.TenantRole{},
+				MachineRoles: map[string]apiv2.MachineRole{},
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				IssuedAt:     timestamppb.New(iat),
+				Expires:      timestamppb.New(exp),
+			},
+			state: state{
+				providerTenant: test.DefaultProviderTenant,
+			},
+			wantToken: &apiv2.Token{
+				Uuid: token1,
+				User: "phippy",
+				Permissions: []*apiv2.MethodPermission{
+					{
+						Subject: "",
+						Methods: []string{
+							"/metalstack.api.v2.PartitionService/List",
+							"/metalstack.api.v2.TokenService/Refresh",
+							"/metalstack.infra.v2.ComponentService/Ping",
+						},
+					},
+				},
+				ProjectRoles: map[string]apiv2.ProjectRole{},
+				TenantRoles:  map[string]apiv2.TenantRole{},
+				MachineRoles: map[string]apiv2.MachineRole{},
+				TokenType:    apiv2.TokenType_TOKEN_TYPE_API,
+				IssuedAt:     timestamppb.New(exp),
+				Expires:      timestamppb.New(exp.Add(time.Hour)),
+				Meta: &apiv2.Meta{
+					Generation: 1,
+				},
+			},
+		},
 		// FIXME more tests
 		{
 			name: "token does not exist in database",


### PR DESCRIPTION
## Description

We struggled to create useful token for the image cache. Debug this

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
