### PR TITLE
Update err msg to match check

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -332,7 +332,7 @@ Can not be changed after initial creation.
 		Sources: cli.EnvVars("BMC_SUPER_USER_PASSWORD"),
 		Action: func(ctx context.Context, cmd *cli.Command, s string) error {
 			if len(s) < 8 {
-				return fmt.Errorf("bmc superuser password must be longer than 2 characters")
+				return fmt.Errorf("bmc superuser password must be longer than 8 characters")
 			}
 			return nil
 		},


### PR DESCRIPTION
## Description

Updates the error message to match the actual check.

#### Used AI-Tools ✨

- [open-code-review](https://open-codereview.ai/) used for finding it, fix is by me :-)

```
─── cmd/server/main.go:333-338 ───                                                                                                                                                                                                                                                                                            
[bug · high] Mismatched validation logic and error message. The Action closure for                                                                                                                                                                                                                                            
`bmc-superuser-pwd` enforces a minimum length of 8 characters (`len(s) < 8`) on line 334, but the                                                                                                                                                                                                                             
error message on line 335 says "must be longer than 2 characters". This discrepancy misleads                                                                                                                                                                                                                                  
operators — if they see the error, they might think 3 characters is sufficient, when in fact at                                                                                                                                                                                                                               
least 8 are required. Fix: update the error message to match the check, e.g., "bmc superuser                                                                                                                                                                                                                                  
password must be at least 8 characters long". 
```