### PR TITLE
Log token uuid and duration of call

### DIFF
--- a/pkg/repository/token_test.go
+++ b/pkg/repository/token_test.go
@@ -99,8 +99,7 @@ func parseJWTToken(tokenString string) (*token.Claims, error) {
 	}
 
 	claims := &token.Claims{}
-	parser := jwt.NewParser()
-	_, _, err := parser.ParseUnverified(string(tokenString), claims)
+	_, _, err := jwt.NewParser().ParseUnverified(string(tokenString), claims)
 
 	if err != nil {
 		return nil, err

--- a/pkg/service/log-interceptor.go
+++ b/pkg/service/log-interceptor.go
@@ -109,7 +109,7 @@ func tokenId(ctx context.Context) (string, bool) {
 	tokenString := auth[len(prefix):]
 
 	claims := &token.Claims{}
-	_, _, err := jwt.NewParser().ParseUnverified(string(tokenString), claims)
+	_, _, err := jwt.NewParser().ParseUnverified(tokenString, claims)
 	if err != nil {
 		return "", false
 	}

--- a/pkg/service/log-interceptor.go
+++ b/pkg/service/log-interceptor.go
@@ -3,9 +3,11 @@ package service
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/metal-stack/metal-apiserver/pkg/token"
 )
 
@@ -27,9 +29,9 @@ func (i *logInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			start = time.Now()
 		)
 
-		tok, ok := token.TokenFromContext(ctx)
+		tokenId, ok := tokenId(ctx)
 		if ok {
-			log = log.With("token uuid", tok.Uuid)
+			log = log.With("token", tokenId)
 		}
 
 		if debug {
@@ -87,4 +89,30 @@ func (w *wrapper) Receive(m any) error {
 	procedure := w.StreamingHandlerConn.Spec().Procedure
 	w.log.Debug("streaminghandler receive called", "procedure", procedure, "message", m)
 	return w.StreamingHandlerConn.Receive(m)
+}
+
+const (
+	prefix              = "Bearer "
+	authorizationHeader = "Authorization"
+)
+
+func tokenId(ctx context.Context) (string, bool) {
+	callinfo, ok := connect.CallInfoForHandlerContext(ctx)
+	if !ok {
+		return "", false
+	}
+	auth := callinfo.RequestHeader().Get(authorizationHeader)
+	// Case insensitive prefix match. See RFC 9110 Section 11.1.
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return "", false
+	}
+	tokenString := auth[len(prefix):]
+
+	claims := &token.Claims{}
+	_, _, err := jwt.NewParser().ParseUnverified(string(tokenString), claims)
+	if err != nil {
+		return "", false
+	}
+
+	return claims.ID, true
 }

--- a/pkg/service/log-interceptor.go
+++ b/pkg/service/log-interceptor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/metal-stack/metal-apiserver/pkg/token"
 )
 
 type logInterceptor struct {
@@ -26,13 +27,19 @@ func (i *logInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			start = time.Now()
 		)
 
-		if debug {
-			log = log.With("request", req.Any())
+		tok, ok := token.TokenFromContext(ctx)
+		if ok {
+			log = log.With("token uuid", tok.Uuid)
 		}
 
-		log.Info("handling unary call")
+		if debug {
+			log = log.With("request", req.Any())
+			log.Debug("handling unary call")
+		}
 
 		response, err := next(ctx, req)
+
+		log = log.With("duration", time.Since(start).String())
 
 		if debug && response != nil {
 			log = log.With("response", response.Any())
@@ -40,9 +47,9 @@ func (i *logInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 
 		if err != nil {
 			log.Error("error during unary call", "error", err)
-		} else if debug {
-			log.Debug("handled call successfully", "duration", time.Since(start).String())
 		}
+
+		log.Info("handled unary call")
 
 		return response, err
 	}

--- a/pkg/service/log-interceptor_test.go
+++ b/pkg/service/log-interceptor_test.go
@@ -37,7 +37,7 @@ func Test_logInterceptor_AuditingCtx(t *testing.T) {
 			level:       slog.LevelInfo,
 			method:      "/metalstack.api.v2.HealthService/Get",
 			handler:     handler[apiv2.HealthServiceGetRequest, apiv2.HealthServiceGetResponse](),
-			wantContain: `"level":"INFO","msg":"handling unary call","procedure":"/metalstack.api.v2.HealthService/Get"`,
+			wantContain: `"level":"INFO","msg":"handled unary call","procedure":"/metalstack.api.v2.HealthService/Get"`,
 		},
 		{
 			name: "log debug",
@@ -51,7 +51,7 @@ func Test_logInterceptor_AuditingCtx(t *testing.T) {
 			level:       slog.LevelDebug,
 			method:      "/metalstack.api.v2.IPService/Create",
 			handler:     handler[apiv2.IPServiceCreateRequest, apiv2.IPServiceCreateResponse](),
-			wantContain: `"level":"INFO","msg":"handling unary call","procedure":"/metalstack.api.v2.IPService/Create","request":{"network":`,
+			wantContain: `"level":"INFO","msg":"handled unary call","procedure":"/metalstack.api.v2.IPService/Create","request":{"network":`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

This adds to each log line

- token uuid
- call duration


sample:

```
metal-apiserver-68794b7565-bc66b apiserver {"time":"2026-08-27T12:15:46.743208081Z","level":"INFO","msg":"handled unary call","procedure":"/metalstack.infra.v2.SwitchService/Heartbeat","token uuid":"01a0421f-c9d2-73ed-ba34-7024d0d55730","duration":"208.903604ms"}
metal-apiserver-68794b7565-bc66b apiserver {"time":"2026-08-27T12:15:50.601988161Z","level":"ERROR","msg":"error during unary call","procedure":"/metalstack.api.v2.TokenService/Refresh","token uuid":"019fa39c-32b0-7d53-b33d-86a1b8fdedc6","duration":"3.60115ms","error":"unauthenticated: token is not valid, no suitable p
ublickey to validate signature found"}
```

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
